### PR TITLE
Chore/fix inconsistent test ids

### DIFF
--- a/infra/build/packages/viteConfigFor.ts
+++ b/infra/build/packages/viteConfigFor.ts
@@ -41,6 +41,11 @@ export const viteConfigFor = (libName: string) => (overrides: Partial<UserConfig
     environment: 'jsdom',
     globals: true,
     setupFiles: [resolve(__dirname, '../../../vitest.setup.ts')],
+    css: {
+      modules: {
+        classNameStrategy: 'non-scoped',
+      }
+    },
     coverage: {
       provider: 'istanbul',
       reporter: ['html', 'text', 'lcov'],

--- a/infra/build/packages/viteConfigFor.ts
+++ b/infra/build/packages/viteConfigFor.ts
@@ -60,7 +60,7 @@ export const viteConfigFor = (libName: string) => (overrides: Partial<UserConfig
         '**/__mocks__',
         '**/node_modules',
         '**/dist',
-        '**/static',
+        "**/static",
         '**/scripts',
       ],
       thresholds: {

--- a/src/components/layout/Expandable/src/test/Expandable.func.test.tsx
+++ b/src/components/layout/Expandable/src/test/Expandable.func.test.tsx
@@ -7,12 +7,21 @@ import {
 } from './__mocks__/useTranslations';
 
 import { Expandable } from '../Expandable';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import * as React from 'react';
 
-// vi.mock('import.meta.glob', () => Promise.resolve({})); // no-op
 vi.mock('@docodylus/i18n-internal', () => ({ useTranslations: mockUseTranslations }));
 
+let idCounter = 0;
+vi.mock('react', async () => {
+  const actualReact = await vi.importActual<typeof React>('react');
+  function mockUseId() { return `mock${idCounter++}` }
+
+  return { ...actualReact, useId: mockUseId }
+});
+
 describeUnitTest('Core functionality tests', () => {
+  beforeEach(() => idCounter = 0);
   describe('Initial state', () => {
     it('should render collapsed by default and expand when clicked', () => {
       render(<Expandable />);
@@ -116,9 +125,12 @@ describeUnitTest('Core functionality tests', () => {
   });
 
   describe('Snapshots/Visual-Regression', () => {
+
     it('should maintain visual consistency between expanded and collapsed states', () => {
       const { asFragment, rerender } = render(<Expandable startExpanded={false} />);
       expect(asFragment()).toMatchSnapshot();
+
+      screen.debug();
 
       rerender(<Expandable startExpanded />);
       expect(asFragment()).toMatchSnapshot();

--- a/src/components/layout/Expandable/src/test/__snapshots__/Expandable.func.test.tsx.snap
+++ b/src/components/layout/Expandable/src/test/__snapshots__/Expandable.func.test.tsx.snap
@@ -4,21 +4,21 @@ exports[`Core functionality tests > Snapshots/Visual-Regression > should maintai
 <DocumentFragment>
   <div
     aria-live="polite"
-    class="_container_baa81e"
+    class="container"
   >
     <div
-      class="_expandableBlock_baa81e"
-      data-testid="expandable-section-«ra»"
+      class="expandableBlock"
+      data-testid="expandable-section-stable-id-0"
       hidden=""
-      id="expandable-section-«ra»"
+      id="expandable-section-stable-id-0"
       tabindex="-1"
     />
     <button
-      aria-controls="expandable-section-toggle-«ra»"
+      aria-controls="expandable-section-toggle-stable-id-0"
       aria-expanded="false"
-      class="_toggle_baa81e"
-      data-testid="expandable-toggle-«ra»"
-      id="expandable-toggle-«ra»"
+      class="toggle"
+      data-testid="expandable-toggle-stable-id-0"
+      id="expandable-toggle-stable-id-0"
       tabindex="0"
       type="button"
     >
@@ -32,20 +32,20 @@ exports[`Core functionality tests > Snapshots/Visual-Regression > should maintai
 <DocumentFragment>
   <div
     aria-live="polite"
-    class="_container_baa81e"
+    class="container"
   >
     <div
-      class="_expandableBlock_baa81e"
-      data-testid="expandable-section-«ra»"
-      id="expandable-section-«ra»"
+      class="expandableBlock"
+      data-testid="expandable-section-stable-id-2"
+      id="expandable-section-stable-id-2"
       tabindex="-1"
     />
     <button
-      aria-controls="expandable-section-toggle-«ra»"
+      aria-controls="expandable-section-toggle-stable-id-2"
       aria-expanded="true"
-      class="_toggle_baa81e"
-      data-testid="expandable-toggle-«ra»"
-      id="expandable-toggle-«ra»"
+      class="toggle"
+      data-testid="expandable-toggle-stable-id-2"
+      id="expandable-toggle-stable-id-2"
       tabindex="0"
       type="button"
     >

--- a/src/components/layout/Expandable/src/test/__snapshots__/Expandable.func.test.tsx.snap
+++ b/src/components/layout/Expandable/src/test/__snapshots__/Expandable.func.test.tsx.snap
@@ -8,17 +8,17 @@ exports[`Core functionality tests > Snapshots/Visual-Regression > should maintai
   >
     <div
       class="expandableBlock"
-      data-testid="expandable-section-stable-id-0"
+      data-testid="expandable-section-mock0"
       hidden=""
-      id="expandable-section-stable-id-0"
+      id="expandable-section-mock0"
       tabindex="-1"
     />
     <button
-      aria-controls="expandable-section-toggle-stable-id-0"
+      aria-controls="expandable-section-toggle-mock0"
       aria-expanded="false"
       class="toggle"
-      data-testid="expandable-toggle-stable-id-0"
-      id="expandable-toggle-stable-id-0"
+      data-testid="expandable-toggle-mock0"
+      id="expandable-toggle-mock0"
       tabindex="0"
       type="button"
     >
@@ -36,16 +36,16 @@ exports[`Core functionality tests > Snapshots/Visual-Regression > should maintai
   >
     <div
       class="expandableBlock"
-      data-testid="expandable-section-stable-id-2"
-      id="expandable-section-stable-id-2"
+      data-testid="expandable-section-mock2"
+      id="expandable-section-mock2"
       tabindex="-1"
     />
     <button
-      aria-controls="expandable-section-toggle-stable-id-2"
+      aria-controls="expandable-section-toggle-mock2"
       aria-expanded="true"
       class="toggle"
-      data-testid="expandable-toggle-stable-id-2"
-      id="expandable-toggle-stable-id-2"
+      data-testid="expandable-toggle-mock2"
+      id="expandable-toggle-mock2"
       tabindex="0"
       type="button"
     >

--- a/src/components/layout/Expandable/vite.config.ts
+++ b/src/components/layout/Expandable/vite.config.ts
@@ -11,10 +11,4 @@ export default viteConfigFor('docodylusI18n')({
             ],
         }
     },
-    css: {
-        modules: {
-        scopeBehaviour: 'local',
-        generateScopedName: '[name]__[local]__[hash:base64:5]',
-        },
-    },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',
+    css:  {
+      modules: {
+        classNameStrategy: 'non-scoped'
+      }
+    },
     include: ['src/**/*.{test,spec}.{js,ts,jsx,tsx}', 'test/**/*.{test,spec}.{js,ts,jsx,tsx}'],
     root: '.',
     coverage: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
         'infra', // TODO: separate coverage metrics for scripts
         'build',
         'static',
+        '**/static',
+        '**/scripts',
         'config',
         '.*', // no dot-files
         '**/vite.config.ts',


### PR DESCRIPTION
## Context
Components use `React.useId()` to generate a consistent identifier for each component, which then gets appended to names of sub-components. They also use CSS Modules which relies on runtime-generated unique CSS class names.

## Problem Statement
Tests that rely on the above elements produce inconsistent IDs depending where the tests run from, causing failures in snapshot-based tests.

<details>
<summary>Screen shot of test failure</summary>
<img width="1422" alt="Screenshot 2025-04-28 at 9 30 25 AM" src="https://github.com/user-attachments/assets/deea7982-452c-4ab7-801f-44178a8227c7" />
</details>

## Likely Cause
* React.useId() generates sequential IDs. The number of component renders prior to a given test causes the ID to vary.
* Vite's implementation of CSS Module generated class names relies on the file path relative to current-working-directory, which varies depending on whether tests are run from the project root or the package root.

## Proposed fixes
* Mock `React.useId` in such a way that the ID-generation logic starts with a fresh initial state before each test
* Set `css.modules.classNameStrategy = 'non-scoped'` in `vitest.config.ts`

## Validation
### Test Run from Project Root

<img width="930" alt="Screenshot 2025-04-28 at 9 19 03 AM" src="https://github.com/user-attachments/assets/3c76a689-bb51-4945-a7ee-f9dcbe4bc30f" />
<details>
<summary>Text capture of test run</summary>

```sh
 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus
      Coverage enabled with istanbul

 ✓ src/common/loadable/internal/src/loaders/createLazyLoaders.test.ts (16 tests | 2 skipped) 37ms
 ✓ src/common/i18n/internal/src/localeNegotiation/negotiateLocales.test.ts (18 tests) 8ms
 ✓ src/common/i18n/internal/src/polyglot/LocaleAwarePolyglot.test.ts (8 tests) 5ms
 ✓ src/common/i18n/internal/src/context/I18nProvider.test.tsx (7 tests) 28ms
stdout | src/components/layout/Expandable/src/test/Expandable.func.test.tsx > Core functionality tests > Snapshots/Visual-Regression > should maintain visual consistency between expanded and collapsed states
[36m<body>[39m
  [36m<div>[39m
    [36m<div[39m
      [33maria-live[39m=[32m"polite"[39m
      [33mclass[39m=[32m"container"[39m
    [36m>[39m
      [36m<div[39m
        [33mclass[39m=[32m"expandableBlock"[39m
        [33mdata-testid[39m=[32m"expandable-section-mock0"[39m
        [33mhidden[39m=[32m""[39m
        [33mid[39m=[32m"expandable-section-mock0"[39m
        [33mtabindex[39m=[32m"-1"[39m
      [36m/>[39m
      [36m<button[39m
        [33maria-controls[39m=[32m"expandable-section-toggle-mock0"[39m
        [33maria-expanded[39m=[32m"false"[39m
        [33mclass[39m=[32m"toggle"[39m
        [33mdata-testid[39m=[32m"expandable-toggle-mock0"[39m
        [33mid[39m=[32m"expandable-toggle-mock0"[39m
        [33mtabindex[39m=[32m"0"[39m
        [33mtype[39m=[32m"button"[39m
      [36m>[39m
        [0mMOCK_COLLAPSE_PROMPT[0m
      [36m</button>[39m
    [36m</div>[39m
  [36m</div>[39m
[36m</body>[39m

 ✓ src/components/layout/Expandable/src/test/Expandable.func.test.tsx (13 tests) 103ms
 ↓ test/integration/localeNegotiation.test.tsx (5 tests | 5 skipped)
 ↓ src/components/layout/Expandable/src/test/Expandable.i18n-integration.test.tsx (9 tests | 9 skipped)
 ✓ src/common/i18n/internal/src/hooks/useTranslations.test.tsx (11 tests) 138ms
 ✓ src/components/layout/Expandable/src/test/Expandable.a11y.test.tsx (13 tests) 389ms
 ✓ src/common/namespace/internal/src/isValidNamespace.test.ts (31 tests) 3ms
 ✓ src/common/i18n/internal/src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests) 3ms
 ✓ src/common/error/internal/src/DocodylusErrorBase.test.ts (9 tests) 6ms
 ✓ src/common/i18n/internal/src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 6ms
 ✓ src/common/error/internal/src/DocodylusTypeError.test.ts (2 tests) 2ms
 ✓ src/common/namespace/internal/src/createNamespacePrepender.test.ts (9 tests) 4ms
 ✓ src/common/namespace/internal/src/error/newInvalidNamespaceError.test.ts (1 test) 2ms
 ✓ src/common/i18n/internal/src/error/newInvalidLocaleError.test.ts (1 test) 3ms
 ✓ src/common/i18n/internal/src/validation/validateLocale.test.ts (837 tests) 33ms

 Test Files  16 passed | 2 skipped (18)
      Tests  985 passed | 16 skipped (1001)
   Start at  09:23:39
   Duration  2.11s (transform 1.35s, setup 949ms, collect 3.68s, tests 768ms, environment 4.91s, prepare 1.31s)

 % Coverage report from istanbul
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 ...s/internal/src |     100 |      100 |     100 |     100 |                   
  consts.ts        |     100 |      100 |     100 |     100 |                   
 ...r/internal/src |     100 |      100 |     100 |     100 |                   
  ...sErrorBase.ts |     100 |      100 |     100 |     100 |                   
  ...sTypeError.ts |     100 |      100 |     100 |     100 |                   
 ...n/internal/src |     100 |      100 |     100 |     100 |                   
  consts.ts        |     100 |      100 |     100 |     100 |                   
 ...src/_generated |     100 |      100 |     100 |     100 |                   
  validLocales.ts  |     100 |      100 |     100 |     100 |                   
 ...al/src/context |     100 |      100 |     100 |     100 |                   
  I18nContext.tsx  |     100 |      100 |     100 |     100 |                   
  I18nProvider.tsx |     100 |      100 |     100 |     100 |                   
 ...rnal/src/error |     100 |      100 |     100 |     100 |                   
  ...ocaleError.ts |     100 |      100 |     100 |     100 |                   
 ...rnal/src/hooks |     100 |      100 |     100 |     100 |                   
  ...anslations.ts |     100 |      100 |     100 |     100 |                   
 ...al/src/loaders |     100 |      100 |     100 |     100 |                   
  ...ingLoaders.ts |     100 |      100 |     100 |     100 |                   
  ...eLoaderMap.ts |     100 |      100 |     100 |     100 |                   
 ...aleNegotiation |     100 |      100 |     100 |     100 |                   
  ...ateLocales.ts |     100 |      100 |     100 |     100 |                   
 ...c/localization |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
 ...l/src/polyglot |     100 |      100 |     100 |     100 |                   
  ...rePolyglot.ts |     100 |      100 |     100 |     100 |                   
 ...src/validation |     100 |      100 |     100 |     100 |                   
  ...dateLocale.ts |     100 |      100 |     100 |     100 |                   
 ...al/src/loaders |     100 |      100 |     100 |     100 |                   
  ...azyLoaders.ts |     100 |      100 |     100 |     100 |                   
 ...e/internal/src |     100 |      100 |     100 |     100 |                   
  ...ePrepender.ts |     100 |      100 |     100 |     100 |                   
  ...dNamespace.ts |     100 |      100 |     100 |     100 |                   
 ...rnal/src/error |     100 |      100 |     100 |     100 |                   
  ...spaceError.ts |     100 |      100 |     100 |     100 |                   
 ...Expandable/src |     100 |      100 |     100 |     100 |                   
  Expandable.tsx   |     100 |      100 |     100 |     100 |                   
 ...c/localization |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
 ...lization/txlns |     100 |      100 |     100 |     100 |                   
  en.txlns.ts      |     100 |      100 |     100 |     100 |                   
  es.txlns.ts      |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
```

</details>

### Expandable component tests (affected component)
<img width="930" alt="Screenshot 2025-04-28 at 9 28 22 AM" src="https://github.com/user-attachments/assets/204f932a-51a8-41ec-b150-b9adb6d60655" />

<details>
<summary>Test copy of test run</summary>
iain@Iains-MacBook-Pro docodylus % yarn workspace @docodylus/expandable test:unit --coverage
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:12:12:
      12 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:10:12:
      10 │             "import": "./dist/esm/index.mjs",
         ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:11:12:
      11 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/components/layout/Expandable
      Coverage enabled with istanbul

 ✓ src/test/Expandable.func.test.tsx (13 tests) 87ms
 ↓ src/test/Expandable.i18n-integration.test.tsx (9 tests | 9 skipped)
 ✓ src/test/Expandable.a11y.test.tsx (13 tests) 289ms

 Test Files  2 passed | 1 skipped (3)
      Tests  26 passed | 9 skipped (35)
   Start at  09:28:08
   Duration  995ms (transform 327ms, setup 134ms, collect 758ms, tests 376ms, environment 564ms, prepare 131ms)

 % Coverage report from istanbul
------------------------|---------|----------|---------|---------|-------------------
File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------------|---------|----------|---------|---------|-------------------
All files               |     100 |      100 |     100 |     100 |                   
 src                    |     100 |      100 |     100 |     100 |                   
  Expandable.tsx        |     100 |      100 |     100 |     100 |                   
 src/localization       |     100 |      100 |     100 |     100 |                   
  index.ts              |     100 |      100 |     100 |     100 |                   
 src/localization/txlns |     100 |      100 |     100 |     100 |                   
  en.txlns.ts           |     100 |      100 |     100 |     100 |                   
  es.txlns.ts           |     100 |      100 |     100 |     100 |                   
------------------------|---------|----------|---------|---------|-------------------
</details>


### Diff of snapshots before & after
```diff
diff --git a/src/components/layout/Expandable/src/test/__snapshots__/Expandable.func.test.tsx.snap b/src/components/layout/Expandable/src/test/__snapshots__/Expandable.func.test.tsx.snap
index b721403..107f03d 100644
--- a/src/components/layout/Expandable/src/test/__snapshots__/Expandable.func.test.tsx.snap
+++ b/src/components/layout/Expandable/src/test/__snapshots__/Expandable.func.test.tsx.snap
@@ -4,21 +4,21 @@ exports[`Core functionality tests > Snapshots/Visual-Regression > should maintai
 <DocumentFragment>
   <div
     aria-live="polite"
-    class="_container_baa81e"
+    class="container"
   >
     <div
-      class="_expandableBlock_baa81e"
-      data-testid="expandable-section-«ra»"
+      class="expandableBlock"
+      data-testid="expandable-section-mock0"
       hidden=""
-      id="expandable-section-«ra»"
+      id="expandable-section-mock0"
       tabindex="-1"
     />
     <button
-      aria-controls="expandable-section-toggle-«ra»"
+      aria-controls="expandable-section-toggle-mock0"
       aria-expanded="false"
-      class="_toggle_baa81e"
-      data-testid="expandable-toggle-«ra»"
-      id="expandable-toggle-«ra»"
+      class="toggle"
+      data-testid="expandable-toggle-mock0"
+      id="expandable-toggle-mock0"
       tabindex="0"
       type="button"
     >
@@ -32,20 +32,20 @@ exports[`Core functionality tests > Snapshots/Visual-Regression > should maintai
 <DocumentFragment>
   <div
     aria-live="polite"
-    class="_container_baa81e"
+    class="container"
   >
     <div
-      class="_expandableBlock_baa81e"
-      data-testid="expandable-section-«ra»"
-      id="expandable-section-«ra»"
+      class="expandableBlock"
+      data-testid="expandable-section-mock2"
+      id="expandable-section-mock2"
       tabindex="-1"
     />
     <button
-      aria-controls="expandable-section-toggle-«ra»"
+      aria-controls="expandable-section-toggle-mock2"
       aria-expanded="true"
-      class="_toggle_baa81e"
-      data-testid="expandable-toggle-«ra»"
-      id="expandable-toggle-«ra»"
+      class="toggle"
+      data-testid="expandable-toggle-mock2"
+      id="expandable-toggle-mock2"
       tabindex="0"
       type="button"
     >

```
