### PR TITLE
chore: hide new @local directory from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ tsconfig.vitest-temp.json
 # Local Environment
 .DS_Store
 .local
+@local
 site


### PR DESCRIPTION
I've added a "@local" folder for symlinks into various places in the local environment that are occasionally useful to have quick access to. Screen captures, SSH configs, etc. This change hides that local-only directory from git with .gitignore.