### PR TITLE
refactor: consolidate **tsconfig** configuration properties

### DIFF
--- a/infra/build/packages/tsconfig.base.json
+++ b/infra/build/packages/tsconfig.base.json
@@ -45,16 +45,4 @@
           "@validation/*": ["src/common/validation/internal"],
       },
     },
-
-    // identify which files are outside a package's scope
-    "exclude": [
-      "node_modules",
-      "**/dist",
-      "**/*.test-d.*",
-      "**/*.test.*",
-      "**/__mocks__",
-      "**/__snapshots__",
-      "**/*.md",
-      "**/*.mdx"
-    ],
   }

--- a/src/common/consts/internal/tsconfig.json
+++ b/src/common/consts/internal/tsconfig.json
@@ -1,8 +1,17 @@
 {
-    "extends": "../../../../infra/build/packages/tsconfig.base.json",
+    "extends": ["../../../../infra/build/packages/tsconfig.base.json"],
+    "include": ["index.ts", "src"],
+    "exclude": [
+      "node_modules",
+      "**/dist",
+      "**/*.test-d.*",
+      "**/*.test.*",
+      "**/__mocks__",
+      "**/__snapshots__",
+      "**/*.md",
+      "**/*.mdx"
+    ],
     "compilerOptions": {
       "baseUrl": ".",
     },
-    "include": ["index.ts", "src"],
-    "exclude": ["src/**/__mocks__", "src/**/*.test.*"]
 }

--- a/src/common/error/internal/tsconfig.json
+++ b/src/common/error/internal/tsconfig.json
@@ -1,8 +1,17 @@
 {
     "extends": "../../../../infra/build/packages/tsconfig.base.json",
+    "include": ["index.ts", "src"],
+    "exclude": [
+      "node_modules",
+      "**/dist",
+      "**/*.test-d.*",
+      "**/*.test.*",
+      "**/__mocks__",
+      "**/__snapshots__",
+      "**/*.md",
+      "**/*.mdx"
+    ],
     "compilerOptions": {
       "baseUrl": ".",
     },
-    "include": ["index.ts", "src"],
-    "exclude": ["src/**/__mocks__", "src/**/*.test.*"]
 }

--- a/src/common/error/tsconfig.json
+++ b/src/common/error/tsconfig.json
@@ -1,8 +1,17 @@
 {
     "extends": "../../../infra/build/packages/tsconfig.base.json",
+    "include": ["index.ts", "src"],
+    "exclude": [
+      "node_modules",
+      "**/dist",
+      "**/*.test-d.*",
+      "**/*.test.*",
+      "**/__mocks__",
+      "**/__snapshots__",
+      "**/*.md",
+      "**/*.mdx"
+    ],
     "compilerOptions": {
       "baseUrl": ".",
     },
-    "include": ["index.ts", "src"],
-    "exclude": ["src/**/__mocks__", "src/**/*.test.*"]
 }

--- a/src/common/i18n/extend/tsconfig.json
+++ b/src/common/i18n/extend/tsconfig.json
@@ -1,13 +1,7 @@
 {
     "extends": "../../../../infra/build/packages/tsconfig.base.json",
+    "include": ["index.ts", "src", "tsconfig.test.json"],
     "compilerOptions": {
       "baseUrl": ".",
     },
-    "include": ["index.ts", "src", "tsconfig.test.json"],
-    "exclude": [
-      "node_modules",
-      "dist",
-      "**/*.test.*",
-      "**/*.test-d.ts"
-    ],
 }

--- a/src/common/i18n/internal/tsconfig.json
+++ b/src/common/i18n/internal/tsconfig.json
@@ -1,16 +1,17 @@
 {
     "extends": "../../../../infra/build/packages/tsconfig.base.json",
-    "compilerOptions": {
-      "baseUrl": ".",
-      "paths": {
-        "@error": ["../../error/internal"]
-      }
-    },
-    "include": ["index.ts", "src", "tsconfig.test.json"],
+    "include": [
+      "index.ts",
+      "src"
+    ],
     "exclude": [
       "node_modules",
-      "dist",
+      "**/dist",
+      "**/*.test-d.*",
       "**/*.test.*",
-      "**/*.test-d.ts"
+      "**/__mocks__",
+      "**/__snapshots__",
+      "**/*.md",
+      "**/*.mdx"
     ],
 }

--- a/src/common/i18n/tsconfig.json
+++ b/src/common/i18n/tsconfig.json
@@ -1,16 +1,17 @@
 {
     "extends": "../../../infra/build/packages/tsconfig.base.json",
-    "compilerOptions": {
-      "baseUrl": ".",
-      "paths": {
-        "@error": ["../../error/internal"]
-      }
-    },
-    "include": ["index.ts", "src", "tsconfig.test.json"],
+    "include": ["index.ts", "src"],
     "exclude": [
       "node_modules",
-      "dist",
+      "**/dist",
+      "**/*.test-d.*",
       "**/*.test.*",
-      "**/*.test-d.ts",
+      "**/__mocks__",
+      "**/__snapshots__",
+      "**/*.md",
+      "**/*.mdx"
     ],
+    "compilerOptions": {
+      "baseUrl": ".",
+    }
 }

--- a/src/common/loadable/internal/tsconfig.json
+++ b/src/common/loadable/internal/tsconfig.json
@@ -1,8 +1,17 @@
 {
     "extends": "../../../../infra/build/packages/tsconfig.base.json",
+    "include": ["index.ts", "src"],
     "compilerOptions": {
       "baseUrl": ".",
     },
-    "include": ["index.ts", "src"],
-    "exclude": ["src/**/__mocks__", "src/**/*.test.*"]
+    "exclude": [
+      "node_modules",
+      "**/dist",
+      "**/*.test-d.*",
+      "**/*.test.*",
+      "**/__mocks__",
+      "**/__snapshots__",
+      "**/*.md",
+      "**/*.mdx"
+    ],
 }

--- a/src/common/namespace/internal/tsconfig.json
+++ b/src/common/namespace/internal/tsconfig.json
@@ -1,13 +1,17 @@
 {
     "extends": "../../../../infra/build/packages/tsconfig.base.json",
+    "include": ["index.ts", "src"],
     "compilerOptions": {
       "baseUrl": ".",
     },
-    "include": ["index.ts", "src"],
     "exclude": [
       "node_modules",
-      "dist",
+      "**/dist",
+      "**/*.test-d.*",
       "**/*.test.*",
-      "**/*.test-d.ts"
+      "**/__mocks__",
+      "**/__snapshots__",
+      "**/*.md",
+      "**/*.mdx"
     ],
 }

--- a/src/common/validation/internal/tsconfig.json
+++ b/src/common/validation/internal/tsconfig.json
@@ -1,8 +1,17 @@
 {
     "extends": "../../../../infra/build/packages/tsconfig.base.json",
+    "include": ["index.ts", "src"],
     "compilerOptions": {
       "baseUrl": ".",
-    },
-    "include": ["index.ts", "src"],
-    "exclude": ["src/**/__mocks__", "src/**/*.test.*"]
+    }, 
+    "exclude": [
+      "node_modules",
+      "**/dist",
+      "**/*.test-d.*",
+      "**/*.test.*",
+      "**/__mocks__",
+      "**/__snapshots__",
+      "**/*.md",
+      "**/*.mdx"
+    ],
 }

--- a/src/components/layout/Expandable/tsconfig.json
+++ b/src/components/layout/Expandable/tsconfig.json
@@ -8,13 +8,15 @@
       "src",
       "../../../../infra/types/css-modules.d.ts",
       "../../../../infra/types/mdx.d.ts"
-    ],
+    ], 
     "exclude": [
       "node_modules",
-      "dist",
+      "**/dist",
+      "**/*.test-d.*",
       "**/*.test.*",
-      "**/*.test-d.ts",
-      "**/*.stories.*",
-      "**/*.docs.*"
+      "**/__mocks__",
+      "**/__snapshots__",
+      "**/*.md",
+      "**/*.mdx"
     ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,43 +1,8 @@
 {
+    "extends": ["./infra/build/packages/tsconfig.base.json"],
+    "include": [ "**/*" ],
+    "exclude": [],
     "compilerOptions": {
-        "composite": true,
-        "jsx": "react-jsx",
-        "lib": ["dom", "esnext"],
-        "module": "esnext",
-        "moduleResolution": "bundler",
-        "typeRoots": ["node_modules/@types"], "target": "esnext",
-        "strict": true,
-        "noImplicitAny": true,
-        "baseUrl": "./",
-        "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true,
-        "types": [
-            "react",
-            "react-dom",
-            "node-polyglot",
-            "vite/client",
-        ],
-        "paths": {
-            // infra, docs, & test stuff
-            "@docs/*": ["docs/*"],
-            "@dummies/*": ["infra/dummies/*"],
-            "@storybook-customizations/*": ["infra/storybook/customizations/*"],
-            "@test-utils/*": ["infra/testUtils/*"],
-
-            // library components
-            "@components/*": ["src/components/*"],
-
-            // cross-cutting modules
-            "@consts": ["src/common/consts/internal"],
-            "@error": ["src/common/error/internal"],
-            "@i18n": ["src/common/i18n/internal"],
-            "@i18n-extend": ["src/common/i18n/extend"],
-            "@loadable": ["src/common/loadable/internal"],
-            "@namespace/*": ["src/common/namespace/internal"],
-            "@validation/*": ["src/common/validation/internal"],
-        },
+        "baseUrl": ".",
     },
-    "include": [
-        "**/*",
-    ],
 }


### PR DESCRIPTION
## Context
working towards some fixes that will likely require touching config files.

## Problem Statement
Current state of TypeScript config files has properties duplicated, and it's not really clear what file has sway over a particular scope.

## Proposed Solution
Tighten up the TSConfig  files to centralize, minimize duplication, adn clarify scope.

##  Validation
### Unit Tests (with coverage)
![Screenshot 2025-05-02 at 9 30 01 AM](https://github.com/user-attachments/assets/03c185eb-c6cd-49c4-85e7-25816749d6fd)
_Note: type checking currently disabled. Fixing typechecking is one of the goals of the current effort_

<details>
<summary>Test-run output (as text)</summary>
```sh
iain@Iains-MacBook-Pro docodylus % yarn test:unit --coverage --run

 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus
      Coverage enabled with istanbul

 ✓ src/common/loadable/internal/src/loaders/createLazyLoaders.test.ts (16 tests | 2 skipped) 50ms
 ✓ src/common/i18n/internal/src/localeNegotiation/negotiateLocales.test.ts (18 tests) 7ms
 ✓ src/common/i18n/internal/src/polyglot/LocaleAwarePolyglot.test.ts (8 tests) 5ms
 ✓ src/common/i18n/internal/src/context/I18nProvider.test.tsx (7 tests) 28ms
 ↓ test/integration/localeNegotiation.test.tsx (5 tests | 5 skipped)
 ✓ src/components/layout/Expandable/src/test/Expandable.func.test.tsx (13 tests) 103ms
stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should automatically load localized strings for the default locale
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act

stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should load localized strings for the requested locale and the default locale
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act

stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all negotiated files have loaded
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"

 ↓ src/components/layout/Expandable/src/test/Expandable.i18n-integration.test.tsx (9 tests | 9 skipped)
stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Failed to load translations from https://mock-domain/localization/fr.txlns.ts: undefined

stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"

 ✓ src/common/i18n/internal/src/hooks/useTranslations.test.tsx (11 tests) 121ms
 ✓ src/components/layout/Expandable/src/test/Expandable.a11y.test.tsx (13 tests) 362ms
 ✓ src/common/i18n/internal/src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests) 3ms
 ✓ src/common/error/internal/src/DocodylusErrorBase.test.ts (9 tests) 6ms
 ✓ src/common/namespace/internal/src/isValidNamespace.test.ts (31 tests) 5ms
 ✓ src/common/i18n/internal/src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 5ms
 ✓ src/common/error/internal/src/DocodylusTypeError.test.ts (2 tests) 2ms
 ✓ src/common/namespace/internal/src/createNamespacePrepender.test.ts (9 tests) 2ms
 ✓ src/common/namespace/internal/src/error/newInvalidNamespaceError.test.ts (1 test) 2ms
 ✓ src/common/i18n/internal/src/error/newInvalidLocaleError.test.ts (1 test) 2ms
 ✓ src/common/i18n/internal/src/validation/validateLocale.test.ts (837 tests) 32ms

 Test Files  16 passed | 2 skipped (18)
      Tests  985 passed | 16 skipped (1001)
   Start at  09:29:20
   Duration  1.87s (transform 1.16s, setup 1.09s, collect 3.33s, tests 736ms, environment 4.46s, prepare 1.13s)

 % Coverage report from istanbul
-----------------------------------------------------|---------|----------|---------|---------|-------------------
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------------------------------|---------|----------|---------|---------|-------------------
All files                                            |     100 |      100 |     100 |     100 |                   
 common/consts/internal/src                          |     100 |      100 |     100 |     100 |                   
  consts.ts                                          |     100 |      100 |     100 |     100 |                   
 common/error/internal/src                           |     100 |      100 |     100 |     100 |                   
  DocodylusErrorBase.ts                              |     100 |      100 |     100 |     100 |                   
  DocodylusTypeError.ts                              |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src                            |     100 |      100 |     100 |     100 |                   
  consts.ts                                          |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/_generated                 |     100 |      100 |     100 |     100 |                   
  validLocales.ts                                    |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/context                    |     100 |      100 |     100 |     100 |                   
  I18nContext.tsx                                    |     100 |      100 |     100 |     100 |                   
  I18nProvider.tsx                                   |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/error                      |     100 |      100 |     100 |     100 |                   
  newInvalidLocaleError.ts                           |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/hooks                      |     100 |      100 |     100 |     100 |                   
  useTranslations.ts                                 |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/loaders                    |     100 |      100 |     100 |     100 |                   
  createLocalizationStringLoaders.ts                 |     100 |      100 |     100 |     100 |                   
  toLocalizationFileLoaderMap.ts                     |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/localeNegotiation          |     100 |      100 |     100 |     100 |                   
  negotiateLocales.ts                                |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/localization               |     100 |      100 |     100 |     100 |                   
  index.ts                                           |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/polyglot                   |     100 |      100 |     100 |     100 |                   
  LocaleAwarePolyglot.ts                             |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/validation                 |     100 |      100 |     100 |     100 |                   
  validateLocale.ts                                  |     100 |      100 |     100 |     100 |                   
 common/loadable/internal/src/loaders                |     100 |      100 |     100 |     100 |                   
  createLazyLoaders.ts                               |     100 |      100 |     100 |     100 |                   
 common/namespace/internal/src                       |     100 |      100 |     100 |     100 |                   
  createNamespacePrepender.ts                        |     100 |      100 |     100 |     100 |                   
  isValidNamespace.ts                                |     100 |      100 |     100 |     100 |                   
 common/namespace/internal/src/error                 |     100 |      100 |     100 |     100 |                   
  newInvalidNamespaceError.ts                        |     100 |      100 |     100 |     100 |                   
 components/layout/Expandable/src                    |     100 |      100 |     100 |     100 |                   
  Expandable.tsx                                     |     100 |      100 |     100 |     100 |                   
 components/layout/Expandable/src/localization       |     100 |      100 |     100 |     100 |                   
  index.ts                                           |     100 |      100 |     100 |     100 |                   
 components/layout/Expandable/src/localization/txlns |     100 |      100 |     100 |     100 |                   
  en.txlns.ts                                        |     100 |      100 |     100 |     100 |                   
  es.txlns.ts                                        |     100 |      100 |     100 |     100 |                   
-----------------------------------------------------|---------|----------|---------|---------|-------------------
```
</details>

### Integration Tests (no coverage)
![Screenshot 2025-05-02 at 9 31 49 AM](https://github.com/user-attachments/assets/7860a9b3-e1d3-493a-89b7-e5abfe30e061)
<details>
<summary>Full text of test-run output</summary>
```sh
 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus

 ✓ src/common/loadable/internal/src/loaders/createLazyLoaders.test.ts (16 tests | 14 skipped) 13ms
 ↓ src/common/i18n/internal/src/polyglot/LocaleAwarePolyglot.test.ts (8 tests | 8 skipped)
 ↓ src/common/i18n/internal/src/localeNegotiation/negotiateLocales.test.ts (18 tests | 18 skipped)
 ↓ src/common/i18n/internal/src/context/I18nProvider.test.tsx (7 tests | 7 skipped)
 ↓ src/components/layout/Expandable/src/test/Expandable.func.test.tsx (13 tests | 13 skipped)
 ↓ src/components/layout/Expandable/src/test/Expandable.a11y.test.tsx (13 tests | 13 skipped)
 ↓ src/common/i18n/internal/src/hooks/useTranslations.test.tsx (11 tests | 11 skipped)
 ✓ src/components/layout/Expandable/src/test/Expandable.i18n-integration.test.tsx (9 tests) 232ms
 ✓ test/integration/localeNegotiation.test.tsx (5 tests) 296ms
 ↓ src/common/i18n/internal/src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests | 8 skipped)
 ↓ src/common/error/internal/src/DocodylusErrorBase.test.ts (9 tests | 9 skipped)
 ↓ src/common/namespace/internal/src/isValidNamespace.test.ts (31 tests | 31 skipped)
 ↓ src/common/error/internal/src/DocodylusTypeError.test.ts (2 tests | 2 skipped)
 ↓ src/common/namespace/internal/src/createNamespacePrepender.test.ts (9 tests | 9 skipped)
 ✓ src/common/i18n/internal/src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 7ms
 ↓ src/common/namespace/internal/src/error/newInvalidNamespaceError.test.ts (1 test | 1 skipped)
 ↓ src/common/i18n/internal/src/error/newInvalidLocaleError.test.ts (1 test | 1 skipped)
 ✓ src/common/i18n/internal/src/validation/validateLocale.test.ts (837 tests) 29ms

 Test Files  5 passed | 13 skipped (18)
      Tests  856 passed | 145 skipped (1001)
   Start at  09:31:35
   Duration  1.72s (transform 755ms, setup 1.10s, collect 2.14s, tests 577ms, environment 4.94s, prepare 1.09s)
```
</details>

### Other validations:
* ✅ Unit  tests run successfully, with coverage, per-workspace, severally
* ✅  successful build of all workspaces
* ✅ successful run of Storybook


