### PR TITLE
chore: add --passWithNoTests script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "build:changed": "SINCE=origin/main yarn build:since",
     "build:lastcommit": "SINCE=HEAD~1 yarn build:since",
     "test:unit": "TEST_GROUP=UNIT vitest",
+    "test:unit-several": "yarn workspaces foreach -Ap run test:unit --run --passWithNoTests",
     "test:types": "TEST_GROUP=TYPE vitest --typecheck",
     "test:integration": "TEST_GROUP=INTEGRATION vitest",
     "lint": "eslint .",


### PR DESCRIPTION
## Context
Two modules in particular have no tests:
`@docodylus/consts` defines only shared constants, and has no executable code to test
`@docodylus/validation` has only types (compile time logic)

## Problem Statement
running tests per workspace causes the total test run to fail when it encounters any workspace for which there are no tests. A test-less workspace/module should be an allowable condition

## Proposed Solution
Add a **package.json** script that leverages the vitest `--passWithNoTests` flag to allow testing all workspaces severally with a single command

## Validation
<details>
<summary>Text-output of test run using the new script</summary>

```sh

 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/common/consts/internal
      Coverage enabled with istanbul

No test files found, exiting with code 0

 % Coverage report from istanbul
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:11:12:
      11 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:9:12:
      9 │             "import": "./dist/esm/index.mjs",
        ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:10:12:
      10 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~

include: **/*.{test,spec}.{js,ts,jsx,tsx}
exclude:  **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/common/error
      Coverage enabled with istanbul

 ✓ internal/src/DocodylusTypeError.test.ts (2 tests) 3ms
 ✓ internal/src/DocodylusErrorBase.test.ts (9 tests) 10ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
   Start at  12:32:54
   Duration  1.63s (transform 158ms, setup 312ms, collect 345ms, tests 13ms, environment 1.07s, prepare 633ms)

 % Coverage report from istanbul
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 ...usErrorBase.ts |     100 |      100 |     100 |     100 |                   
 ...usTypeError.ts |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:11:12:
      11 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:9:12:
      9 │             "import": "./dist/esm/index.mjs",
        ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:10:12:
      10 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/common/error/internal
      Coverage enabled with istanbul

 ✓ src/DocodylusTypeError.test.ts (2 tests) 2ms
 ✓ src/DocodylusErrorBase.test.ts (9 tests) 6ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
   Start at  12:32:54
   Duration  1.56s (transform 284ms, setup 521ms, collect 279ms, tests 8ms, environment 1.02s, prepare 424ms)

 % Coverage report from istanbul
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 ...usErrorBase.ts |     100 |      100 |     100 |     100 |                   
 ...usTypeError.ts |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    ../package.json:11:12:
      11 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    ../package.json:9:12:
      9 │             "import": "./dist/esm/index.mjs",
        ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    ../package.json:10:12:
      10 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/common/i18n
      Coverage enabled with istanbul

 ✓ internal/src/error/newInvalidLocaleError.test.ts (1 test) 3ms
 ✓ internal/src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests) 5ms
 ✓ internal/src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 17ms
 ✓ internal/src/localeNegotiation/negotiateLocales.test.ts (18 tests) 7ms
 ✓ internal/src/polyglot/LocaleAwarePolyglot.test.ts (8 tests) 15ms
 ✓ internal/src/context/I18nProvider.test.tsx (7 tests) 32ms
 ✓ internal/src/validation/validateLocale.test.ts (837 tests) 64ms
 ✓ internal/src/hooks/useTranslations.test.tsx (11 tests) 176ms

 Test Files  8 passed (8)
      Tests  893 passed (893)
   Start at  12:32:54
   Duration  2.65s (transform 2.21s, setup 1.27s, collect 6.29s, tests 318ms, environment 3.84s, prepare 2.55s)

 % Coverage report from istanbul
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 src               |     100 |      100 |     100 |     100 |                   
  consts.ts        |     100 |      100 |     100 |     100 |                   
 src/_generated    |     100 |      100 |     100 |     100 |                   
  validLocales.ts  |     100 |      100 |     100 |     100 |                   
 src/context       |     100 |      100 |     100 |     100 |                   
  I18nContext.tsx  |     100 |      100 |     100 |     100 |                   
  I18nProvider.tsx |     100 |      100 |     100 |     100 |                   
 src/error         |     100 |      100 |     100 |     100 |                   
  ...ocaleError.ts |     100 |      100 |     100 |     100 |                   
 src/hooks         |     100 |      100 |     100 |     100 |                   
  ...anslations.ts |     100 |      100 |     100 |     100 |                   
 src/loaders       |     100 |      100 |     100 |     100 |                   
  ...ingLoaders.ts |     100 |      100 |     100 |     100 |                   
  ...eLoaderMap.ts |     100 |      100 |     100 |     100 |                   
 ...aleNegotiation |     100 |      100 |     100 |     100 |                   
  ...ateLocales.ts |     100 |      100 |     100 |     100 |                   
 src/localization  |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
 src/polyglot      |     100 |      100 |     100 |     100 |                   
  ...rePolyglot.ts |     100 |      100 |     100 |     100 |                   
 src/validation    |     100 |      100 |     100 |     100 |                   
  ...dateLocale.ts |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:11:12:
      11 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:9:12:
      9 │             "import": "./dist/esm/index.mjs",
        ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:10:12:
      10 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~

stderr | internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should automatically load localized strings for the default locale
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act

stderr | internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should load localized strings for the requested locale and the default locale
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act

stderr | internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all negotiated files have loaded
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"

stderr | internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Failed to load translations from https://mock-domain/localization/fr.txlns.ts: [90mundefined[39m

stderr | internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus
      Coverage enabled with istanbul

 ✓ src/common/loadable/internal/src/loaders/createLazyLoaders.test.ts (16 tests | 2 skipped) 82ms
 ✓ src/common/i18n/internal/src/localeNegotiation/negotiateLocales.test.ts (18 tests) 9ms
 ✓ src/common/i18n/internal/src/polyglot/LocaleAwarePolyglot.test.ts (8 tests) 5ms
 ✓ src/common/i18n/internal/src/context/I18nProvider.test.tsx (7 tests) 28ms
 ✓ src/components/layout/Expandable/src/test/Expandable.func.test.tsx (13 tests) 103ms
 ↓ test/integration/localeNegotiation.test.tsx (5 tests | 5 skipped)
 ✓ src/components/layout/Expandable/src/test/Expandable.a11y.test.tsx (13 tests) 554ms
 ↓ src/components/layout/Expandable/src/test/Expandable.i18n-integration.test.tsx (9 tests | 9 skipped)
 ✓ src/common/i18n/internal/src/hooks/useTranslations.test.tsx (11 tests) 298ms
 ✓ src/common/error/internal/src/DocodylusErrorBase.test.ts (9 tests) 6ms
 ✓ src/common/error/internal/src/DocodylusTypeError.test.ts (2 tests) 2ms
 ✓ src/common/namespace/internal/src/isValidNamespace.test.ts (31 tests) 3ms
 ✓ src/common/i18n/internal/src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 14ms
 ✓ src/common/namespace/internal/src/createNamespacePrepender.test.ts (9 tests) 5ms
 ✓ src/common/i18n/internal/src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests) 3ms
 ✓ src/common/namespace/internal/src/error/newInvalidNamespaceError.test.ts (1 test) 2ms
 ✓ src/common/i18n/internal/src/error/newInvalidLocaleError.test.ts (1 test) 2ms
 ✓ src/common/i18n/internal/src/validation/validateLocale.test.ts (837 tests) 56ms

 Test Files  16 passed | 2 skipped (18)
      Tests  985 passed | 16 skipped (1001)
   Start at  12:32:53
   Duration  3.83s (transform 3.79s, setup 4.00s, collect 9.58s, tests 1.17s, environment 9.86s, prepare 2.16s)

 % Coverage report from istanbul
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 ...s/internal/src |     100 |      100 |     100 |     100 |                   
  consts.ts        |     100 |      100 |     100 |     100 |                   
 ...r/internal/src |     100 |      100 |     100 |     100 |                   
  ...sErrorBase.ts |     100 |      100 |     100 |     100 |                   
  ...sTypeError.ts |     100 |      100 |     100 |     100 |                   
 ...n/internal/src |     100 |      100 |     100 |     100 |                   
  consts.ts        |     100 |      100 |     100 |     100 |                   
 ...src/_generated |     100 |      100 |     100 |     100 |                   
  validLocales.ts  |     100 |      100 |     100 |     100 |                   
 ...al/src/context |     100 |      100 |     100 |     100 |                   
  I18nContext.tsx  |     100 |      100 |     100 |     100 |                   
  I18nProvider.tsx |     100 |      100 |     100 |     100 |                   
 ...rnal/src/error |     100 |      100 |     100 |     100 |                   
  ...ocaleError.ts |     100 |      100 |     100 |     100 |                   
 ...rnal/src/hooks |     100 |      100 |     100 |     100 |                   
  ...anslations.ts |     100 |      100 |     100 |     100 |                   
 ...al/src/loaders |     100 |      100 |     100 |     100 |                   
  ...ingLoaders.ts |     100 |      100 |     100 |     100 |                   
  ...eLoaderMap.ts |     100 |      100 |     100 |     100 |                   
 ...aleNegotiation |     100 |      100 |     100 |     100 |                   
  ...ateLocales.ts |     100 |      100 |     100 |     100 |                   
 ...c/localization |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
 ...l/src/polyglot |     100 |      100 |     100 |     100 |                   
  ...rePolyglot.ts |     100 |      100 |     100 |     100 |                   
 ...src/validation |     100 |      100 |     100 |     100 |                   
  ...dateLocale.ts |     100 |      100 |     100 |     100 |                   
 ...al/src/loaders |     100 |      100 |     100 |     100 |                   
  ...azyLoaders.ts |     100 |      100 |     100 |     100 |                   
 ...e/internal/src |     100 |      100 |     100 |     100 |                   
  ...ePrepender.ts |     100 |      100 |     100 |     100 |                   
  ...dNamespace.ts |     100 |      100 |     100 |     100 |                   
 ...rnal/src/error |     100 |      100 |     100 |     100 |                   
  ...spaceError.ts |     100 |      100 |     100 |     100 |                   
 ...Expandable/src |     100 |      100 |     100 |     100 |                   
  Expandable.tsx   |     100 |      100 |     100 |     100 |                   
 ...c/localization |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
 ...lization/txlns |     100 |      100 |     100 |     100 |                   
  en.txlns.ts      |     100 |      100 |     100 |     100 |                   
  es.txlns.ts      |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should automatically load localized strings for the default locale
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act

stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should load localized strings for the requested locale and the default locale
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act

stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all negotiated files have loaded
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"

stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Failed to load translations from https://mock-domain/localization/fr.txlns.ts: [90mundefined[39m

stderr | src/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/common/i18n/extend
      Coverage enabled with istanbul

No test files found, exiting with code 0

 % Coverage report from istanbul
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    ../package.json:11:12:
      11 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    ../package.json:9:12:
      9 │             "import": "./dist/esm/index.mjs",
        ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    ../package.json:10:12:
      10 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~

▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:11:12:
      11 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:9:12:
      9 │             "import": "./dist/esm/index.mjs",
        ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:10:12:
      10 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~

include: **/*.{test,spec}.{js,ts,jsx,tsx}
exclude:  **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/common/loadable/internal
      Coverage enabled with istanbul

 ✓ src/loaders/createLazyLoaders.test.ts (16 tests | 2 skipped) 24ms

 Test Files  1 passed (1)
      Tests  14 passed | 2 skipped (16)
   Start at  12:32:57
   Duration  1.32s (transform 133ms, setup 297ms, collect 146ms, tests 24ms, environment 364ms, prepare 52ms)

 % Coverage report from istanbul
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 ...LazyLoaders.ts |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:11:12:
      11 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:9:12:
      9 │             "import": "./dist/esm/index.mjs",
        ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:10:12:
      10 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/common/validation/internal
      Coverage enabled with istanbul

No test files found, exiting with code 0

 % Coverage report from istanbul
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:12:12:
      12 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:10:12:
      10 │             "import": "./dist/esm/index.mjs",
         ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:11:12:
      11 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~

include: **/*.{test,spec}.{js,ts,jsx,tsx}
exclude:  **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/common/namespace/internal
      Coverage enabled with istanbul

 ✓ src/error/newInvalidNamespaceError.test.ts (1 test) 4ms
 ✓ src/isValidNamespace.test.ts (31 tests) 4ms
 ✓ src/createNamespacePrepender.test.ts (9 tests) 3ms

 Test Files  3 passed (3)
      Tests  41 passed (41)
   Start at  12:32:58
   Duration  834ms (transform 229ms, setup 416ms, collect 459ms, tests 11ms, environment 668ms, prepare 292ms)

 % Coverage report from istanbul
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 src               |     100 |      100 |     100 |     100 |                   
  ...ePrepender.ts |     100 |      100 |     100 |     100 |                   
  ...dNamespace.ts |     100 |      100 |     100 |     100 |                   
 src/error         |     100 |      100 |     100 |     100 |                   
  ...spaceError.ts |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:12:12:
      12 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:10:12:
      10 │             "import": "./dist/esm/index.mjs",
         ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:11:12:
      11 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/common/i18n/internal
      Coverage enabled with istanbul

 ✓ src/error/newInvalidLocaleError.test.ts (1 test) 2ms
 ✓ src/localeNegotiation/negotiateLocales.test.ts (18 tests) 8ms
 ✓ src/context/I18nProvider.test.tsx (7 tests) 33ms
 ✓ src/polyglot/LocaleAwarePolyglot.test.ts (8 tests) 5ms
 ✓ src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 7ms
 ✓ src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests) 3ms
 ✓ src/validation/validateLocale.test.ts (837 tests) 47ms
 ✓ src/hooks/useTranslations.test.tsx (11 tests) 130ms

 Test Files  8 passed (8)
      Tests  893 passed (893)
   Start at  12:32:57
   Duration  1.74s (transform 1.01s, setup 1.95s, collect 2.79s, tests 234ms, environment 2.90s, prepare 1.02s)

 % Coverage report from istanbul
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 src               |     100 |      100 |     100 |     100 |                   
  consts.ts        |     100 |      100 |     100 |     100 |                   
 src/_generated    |     100 |      100 |     100 |     100 |                   
  validLocales.ts  |     100 |      100 |     100 |     100 |                   
 src/context       |     100 |      100 |     100 |     100 |                   
  I18nContext.tsx  |     100 |      100 |     100 |     100 |                   
  I18nProvider.tsx |     100 |      100 |     100 |     100 |                   
 src/error         |     100 |      100 |     100 |     100 |                   
  ...ocaleError.ts |     100 |      100 |     100 |     100 |                   
 src/hooks         |     100 |      100 |     100 |     100 |                   
  ...anslations.ts |     100 |      100 |     100 |     100 |                   
 src/loaders       |     100 |      100 |     100 |     100 |                   
  ...ingLoaders.ts |     100 |      100 |     100 |     100 |                   
  ...eLoaderMap.ts |     100 |      100 |     100 |     100 |                   
 ...aleNegotiation |     100 |      100 |     100 |     100 |                   
  ...ateLocales.ts |     100 |      100 |     100 |     100 |                   
 src/localization  |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
 src/polyglot      |     100 |      100 |     100 |     100 |                   
  ...rePolyglot.ts |     100 |      100 |     100 |     100 |                   
 src/validation    |     100 |      100 |     100 |     100 |                   
  ...dateLocale.ts |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    ../package.json:11:12:
      11 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    ../package.json:9:12:
      9 │             "import": "./dist/esm/index.mjs",
        ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    ../package.json:10:12:
      10 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~

▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:12:12:
      12 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:10:12:
      10 │             "import": "./dist/esm/index.mjs",
         ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:11:12:
      11 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~

stderr | src/hooks/useTranslations.test.tsx > useTranslations hook > should automatically load localized strings for the default locale
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act

stderr | src/hooks/useTranslations.test.tsx > useTranslations hook > should load localized strings for the requested locale and the default locale
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act
An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act

stderr | src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all negotiated files have loaded
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"

stderr | src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Failed to load translations from https://mock-domain/localization/fr.txlns.ts: [90mundefined[39m

stderr | src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"


 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus/src/components/layout/Expandable
      Coverage enabled with istanbul

 ✓ src/test/Expandable.func.test.tsx (13 tests) 84ms
 ↓ src/test/Expandable.i18n-integration.test.tsx (9 tests | 9 skipped)
 ✓ src/test/Expandable.a11y.test.tsx (13 tests) 253ms

 Test Files  2 passed | 1 skipped (3)
      Tests  26 passed | 9 skipped (35)
   Start at  12:32:59
   Duration  929ms (transform 315ms, setup 132ms, collect 676ms, tests 337ms, environment 563ms, prepare 159ms)

 % Coverage report from istanbul
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 src               |     100 |      100 |     100 |     100 |                   
  Expandable.tsx   |     100 |      100 |     100 |     100 |                   
 src/localization  |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
 ...lization/txlns |     100 |      100 |     100 |     100 |                   
  en.txlns.ts      |     100 |      100 |     100 |     100 |                   
  es.txlns.ts      |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:12:12:
      12 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:10:12:
      10 │             "import": "./dist/esm/index.mjs",
         ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:11:12:
      11 │             "require": "./dist/cjs/index.cjs",
         ╵             ~~~~~~~~~

Done in 8s 282ms

```
</details>