### PR TITLE
chore: make sure 'act' callbacks are async

### DIFF
--- a/packages/common/i18n/internal/src/hooks/useTranslations.test.tsx
+++ b/packages/common/i18n/internal/src/hooks/useTranslations.test.tsx
@@ -122,8 +122,8 @@ describeUnitTest('useTranslations hook', () => {
     await waitFor(() => expectLoadingState());
   });
 
-  it('should automatically load localized strings for the default locale', () => {
-    act(() => {
+  it('should automatically load localized strings for the default locale', async () => {
+    await act(async () => {
       render(
         <I18nProvider>
           <TestComponent fileLoaders={defaultMockFileLoaders} />
@@ -135,8 +135,8 @@ describeUnitTest('useTranslations hook', () => {
     expect(FR_LOADER_MOCK).not.toBeCalled();
   });
 
-  it('should load localized strings for the requested locale and the default locale', () => {
-    act(() => {
+  it('should load localized strings for the requested locale and the default locale', async () => {
+    await act(async () => {
       render(
         <I18nProvider locale="fr">
           <TestComponent fileLoaders={defaultMockFileLoaders} />


### PR DESCRIPTION
## Problem statement
Getting noisy warnings about async events when running tests, despite render methods already begin wrapped in `act` calls

## Likely cause
renders are using async effects (dynamic loading) but the `await` callbacks are not designated `async` or awaited.

## Proposed fix
Make the callbacks async

## Validation
### Unit test (no `act` warnings in output
![Screenshot 2025-05-02 at 4 20 21 PM](https://github.com/user-attachments/assets/21d83d33-93e9-4e22-badf-709544c4bd54)

### Integration test (no `act` warnings in output)
![Screenshot 2025-05-02 at 4 21 57 PM](https://github.com/user-attachments/assets/48ea5585-b763-40a9-ae40-a0973b0a2cba)

