### PR TITLE
chore: make sure 'types' condition comes before 'import' and 'require…

### DIFF
--- a/packages/common/consts/internal/package.json
+++ b/packages/common/consts/internal/package.json
@@ -5,10 +5,10 @@
     "type": "module",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "development": "./index.ts",
             "import": "./dist/esm/index.mjs",
-            "require": "./dist/cjs/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/cjs/index.cjs"
         }
     },
     "files": [

--- a/packages/common/error/package.json
+++ b/packages/common/error/package.json
@@ -6,9 +6,9 @@
     "sideEffects": false,
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "import": "./dist/esm/index.mjs",
-            "require": "./dist/cjs/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/cjs/index.cjs"
         }
     },
     "files": [

--- a/packages/common/i18n/extend/package.json
+++ b/packages/common/i18n/extend/package.json
@@ -6,9 +6,9 @@
     "sideEffects": false,
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "import": "./dist/esm/index.mjs",
-            "require": "./dist/cjs/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/cjs/index.cjs"
         }
     },
     "files": [

--- a/packages/common/i18n/internal/package.json
+++ b/packages/common/i18n/internal/package.json
@@ -7,9 +7,9 @@
     "exports": {
         ".": {
             "development": "./index.ts",
+            "types": "./dist/index.d.ts",
             "import": "./dist/esm/index.mjs",
-            "require": "./dist/cjs/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/cjs/index.cjs"
         }
     },
     "files": [

--- a/packages/common/i18n/package.json
+++ b/packages/common/i18n/package.json
@@ -6,9 +6,9 @@
     "sideEffects": false,
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "import": "./dist/esm/index.mjs",
-            "require": "./dist/cjs/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/cjs/index.cjs"
         }
     },
     "files": [

--- a/packages/common/loadable/internal/package.json
+++ b/packages/common/loadable/internal/package.json
@@ -5,10 +5,10 @@
     "type": "module",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "development": "./index.ts",
             "import": "./dist/esm/index.mjs",
-            "require": "./dist/cjs/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/cjs/index.cjs"
         }
     },
     "files": [

--- a/packages/common/namespace/internal/package.json
+++ b/packages/common/namespace/internal/package.json
@@ -6,10 +6,10 @@
     "sideEffects": false,
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "development": "./index.ts",
             "import": "./dist/esm/index.mjs",
-            "require": "./dist/cjs/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/cjs/index.cjs"
         }
     },
     "files": [

--- a/packages/common/validation/internal/package.json
+++ b/packages/common/validation/internal/package.json
@@ -7,9 +7,9 @@
     "exports": {
         ".": {
             "development": "./index.ts",
+            "types": "./dist/index.d.ts",
             "import": "./dist/esm/index.mjs",
-            "require": "./dist/cjs/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/cjs/index.cjs"
         }
     },
     "files": [

--- a/packages/components/layout/Expandable/package.json
+++ b/packages/components/layout/Expandable/package.json
@@ -6,10 +6,10 @@
     "sideEffects": false,
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "development": "./index.ts",
             "import": "./dist/esm/index.mjs",
-            "require": "./dist/cjs/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/cjs/index.cjs"
         }
     },
     "files": [


### PR DESCRIPTION
## Context
Build output has had these noisy warnings for ages:
```sh
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:12:12:
      12 │             "types": "./dist/index.d.ts"
         ╵             ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:10:12:
      10 │             "import": "./dist/esm/index.mjs",
         ╵             ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:11:12:
      11 │             "require": "./dist/cjs/index.cjs",
```

## Likely cause
Vite uses Rollup under the hood, which in turn uses ESBuild. ESBuild evaluates conditions in the order they appear in the package.json. Previous attempts to resolve the issue this same way have failed because ESBuild navigates _all_ relevant package.json and will throw a warning if _any_ of them has the above condition, but gives no indication that the warning isn't coming from the present package.json.

## Proposed fix
Update _all_ **package.json** files so that "import" and "require" are always the _last two_ conditions.

## Validation
![Screenshot 2025-05-02 at 5 03 25 PM](https://github.com/user-attachments/assets/e04a21d1-c7d1-4eef-b040-2f112f95ea95)

<details>
<summary>Clean output from build of all modules without noisy warnings</summary>

```sh
iain@Iains-MacBook-Pro docodylus % yarn build:all                                                                                                
[@docodylus/consts-internal]: Process started
[@docodylus/error-internal]: Process started
[@docodylus/i18n-extend]: Process started
[@docodylus/validation-internal]: Process started
[@docodylus/validation-internal]: vite v6.3.3 building for production...
[@docodylus/validation-internal]: transforming...
[@docodylus/validation-internal]: ✓ 1 modules transformed.
[@docodylus/validation-internal]: rendering chunks...
[@docodylus/validation-internal]: 
[@docodylus/validation-internal]: [vite:dts] Start generate declaration files...
[@docodylus/validation-internal]: computing gzip size...
[@docodylus/validation-internal]: dist/cjs/index.cjs  0.05 kB │ gzip: 0.07 kB │ map: 0.09 kB
[@docodylus/validation-internal]: [vite:dts] Declaration files built in 816ms.
[@docodylus/validation-internal]: 
[@docodylus/validation-internal]: dist/esm/index.mjs  0.04 kB │ gzip: 0.06 kB │ map: 0.09 kB
[@docodylus/validation-internal]: ✓ built in 850ms
[@docodylus/validation-internal]: Generated an empty chunk: "index".
[@docodylus/validation-internal]: Generated an empty chunk: "index".
[@docodylus/validation-internal]: Process exited (exit code 0), completed in 1s 905ms
[@docodylus/error-internal]: vite v6.3.3 building for production...
[@docodylus/error-internal]: transforming...
[@docodylus/error-internal]: ✓ 3 modules transformed.
[@docodylus/error-internal]: rendering chunks...
[@docodylus/error-internal]: 
[@docodylus/error-internal]: [vite:dts] Start generate declaration files...
[@docodylus/error-internal]: computing gzip size...
[@docodylus/error-internal]: dist/cjs/index.cjs  1.33 kB │ gzip: 0.64 kB │ map: 4.51 kB
[@docodylus/error-internal]: [vite:dts] Declaration files built in 823ms.
[@docodylus/error-internal]: 
[@docodylus/error-internal]: dist/esm/index.mjs  1.87 kB │ gzip: 0.78 kB │ map: 4.70 kB
[@docodylus/error-internal]: ✓ built in 877ms
[@docodylus/error-internal]: Process exited (exit code 0), completed in 2s 54ms
[@docodylus/consts-internal]: vite v6.3.3 building for production...
[@docodylus/consts-internal]: transforming...
[@docodylus/consts-internal]: ✓ 2 modules transformed.
[@docodylus/consts-internal]: rendering chunks...
[@docodylus/consts-internal]: 
[@docodylus/consts-internal]: [vite:dts] Start generate declaration files...
[@docodylus/consts-internal]: computing gzip size...
[@docodylus/consts-internal]: dist/cjs/index.cjs  0.21 kB │ gzip: 0.19 kB │ map: 0.28 kB
[@docodylus/consts-internal]: [vite:dts] Declaration files built in 812ms.
[@docodylus/consts-internal]: 
[@docodylus/consts-internal]: dist/esm/index.mjs  0.14 kB │ gzip: 0.15 kB │ map: 0.28 kB
[@docodylus/consts-internal]: ✓ built in 844ms
[@docodylus/consts-internal]: Process exited (exit code 0), completed in 2s 149ms
[@docodylus/i18n-extend]: vite v6.3.3 building for production...
[@docodylus/i18n-extend]: transforming...
[@docodylus/i18n-extend]: ✓ 1 modules transformed.
[@docodylus/i18n-extend]: rendering chunks...
[@docodylus/i18n-extend]: 
[@docodylus/i18n-extend]: [vite:dts] Start generate declaration files...
[@docodylus/i18n-extend]: computing gzip size...
[@docodylus/i18n-extend]: dist/cjs/index.cjs  0.05 kB │ gzip: 0.07 kB │ map: 0.09 kB
[@docodylus/i18n-extend]: [vite:dts] Declaration files built in 730ms.
[@docodylus/i18n-extend]: 
[@docodylus/i18n-extend]: dist/esm/index.mjs  0.04 kB │ gzip: 0.06 kB │ map: 0.09 kB
[@docodylus/i18n-extend]: ✓ built in 760ms
[@docodylus/i18n-extend]: Generated an empty chunk: "index".
[@docodylus/i18n-extend]: Generated an empty chunk: "index".
[@docodylus/i18n-extend]: Process exited (exit code 0), completed in 2s 191ms
[@docodylus/error]: Process started
[@docodylus/loadable-internal]: Process started
[@docodylus/namespace-internal]: Process started
[@docodylus/namespace-internal]: vite v6.3.3 building for production...
[@docodylus/namespace-internal]: transforming...
[@docodylus/namespace-internal]: ✓ 4 modules transformed.
[@docodylus/namespace-internal]: rendering chunks...
[@docodylus/namespace-internal]: 
[@docodylus/namespace-internal]: [vite:dts] Start generate declaration files...
[@docodylus/namespace-internal]: computing gzip size...
[@docodylus/namespace-internal]: dist/cjs/index.cjs  0.71 kB │ gzip: 0.46 kB │ map: 3.92 kB
[@docodylus/namespace-internal]: [vite:dts] Declaration files built in 763ms.
[@docodylus/namespace-internal]: 
[@docodylus/namespace-internal]: dist/esm/index.mjs  0.73 kB │ gzip: 0.45 kB │ map: 3.96 kB
[@docodylus/namespace-internal]: ✓ built in 806ms
[@docodylus/namespace-internal]: Process exited (exit code 0), completed in 1s 811ms
[@docodylus/loadable-internal]: vite v6.3.3 building for production...
[@docodylus/loadable-internal]: transforming...
[@docodylus/loadable-internal]: ✓ 2 modules transformed.
[@docodylus/loadable-internal]: rendering chunks...
[@docodylus/loadable-internal]: 
[@docodylus/loadable-internal]: [vite:dts] Start generate declaration files...
[@docodylus/loadable-internal]: computing gzip size...
[@docodylus/loadable-internal]: dist/cjs/index.cjs  0.49 kB │ gzip: 0.35 kB │ map: 1.86 kB
[@docodylus/loadable-internal]: [vite:dts] Declaration files built in 737ms.
[@docodylus/loadable-internal]: 
[@docodylus/loadable-internal]: dist/esm/index.mjs  0.56 kB │ gzip: 0.36 kB │ map: 1.90 kB
[@docodylus/loadable-internal]: ✓ built in 779ms
[@docodylus/loadable-internal]: Process exited (exit code 0), completed in 1s 859ms
[@docodylus/error]: vite v6.3.3 building for production...
[@docodylus/error]: transforming...
[@docodylus/error]: ✓ 1 modules transformed.
[@docodylus/error]: rendering chunks...
[@docodylus/error]: 
[@docodylus/error]: [vite:dts] Start generate declaration files...
[@docodylus/error]: computing gzip size...
[@docodylus/error]: dist/cjs/index.cjs  0.26 kB │ gzip: 0.20 kB │ map: 0.09 kB
[@docodylus/error]: [vite:dts] Start rollup declaration files...
[@docodylus/error]: Analysis will use the bundled TypeScript version 5.8.2
[@docodylus/error]: [vite:dts] Declaration files built in 2322ms.
[@docodylus/error]: 
[@docodylus/error]: dist/esm/index.mjs  0.14 kB │ gzip: 0.13 kB │ map: 0.09 kB
[@docodylus/error]: ✓ built in 2.35s
[@docodylus/error]: Process exited (exit code 0), completed in 3s 562ms
[@docodylus/i18n-internal]: Process started
[@docodylus/i18n-internal]: vite v6.3.3 building for production...
[@docodylus/i18n-internal]: transforming...
[@docodylus/i18n-internal]: ✓ 86 modules transformed.
[@docodylus/i18n-internal]: rendering chunks...
[@docodylus/i18n-internal]: 
[@docodylus/i18n-internal]: [vite:dts] Start generate declaration files...
[@docodylus/i18n-internal]: computing gzip size...
[@docodylus/i18n-internal]: dist/cjs/index.cjs  68.24 kB │ gzip: 22.75 kB │ map: 241.03 kB
[@docodylus/i18n-internal]: [vite:dts] Declaration files built in 794ms.
[@docodylus/i18n-internal]: 
[@docodylus/i18n-internal]: dist/esm/index.mjs  100.27 kB │ gzip: 26.50 kB │ map: 253.49 kB
[@docodylus/i18n-internal]: ✓ built in 1.09s
[@docodylus/i18n-internal]: Process exited (exit code 0), completed in 2s 585ms
[@docodylus/i18n]: Process started
[@docodylus/expandable]: Process started
[@docodylus/i18n]: vite v6.3.3 building for production...
[@docodylus/i18n]: transforming...
[@docodylus/i18n]: ✓ 1 modules transformed.
[@docodylus/i18n]: rendering chunks...
[@docodylus/i18n]: 
[@docodylus/i18n]: [vite:dts] Start generate declaration files...
[@docodylus/i18n]: computing gzip size...
[@docodylus/i18n]: dist/cjs/index.cjs  0.25 kB │ gzip: 0.20 kB │ map: 0.09 kB
[@docodylus/i18n]: [vite:dts] Start rollup declaration files...
[@docodylus/i18n]: Analysis will use the bundled TypeScript version 5.8.2
[@docodylus/i18n]: [vite:dts] Declaration files built in 2395ms.
[@docodylus/i18n]: 
[@docodylus/i18n]: dist/esm/index.mjs  0.13 kB │ gzip: 0.13 kB │ map: 0.09 kB
[@docodylus/i18n]: ✓ built in 2.42s
[@docodylus/i18n]: Process exited (exit code 0), completed in 3s 357ms
[@docodylus/expandable]: vite v6.3.3 building for production...
[@docodylus/expandable]: transforming...
[@docodylus/expandable]: ✓ 1 modules transformed.
[@docodylus/expandable]: rendering chunks...
[@docodylus/expandable]: 
[@docodylus/expandable]: [vite:dts] Start generate declaration files...
[@docodylus/expandable]: computing gzip size...
[@docodylus/expandable]: dist/cjs/index.cjs  0.05 kB │ gzip: 0.07 kB │ map: 0.09 kB
[@docodylus/expandable]: [vite:dts] Start rollup declaration files...
[@docodylus/expandable]: Analysis will use the bundled TypeScript version 5.8.2
[@docodylus/expandable]: [vite:dts] Declaration files built in 2581ms.
[@docodylus/expandable]: 
[@docodylus/expandable]: dist/esm/index.mjs  0.04 kB │ gzip: 0.06 kB │ map: 0.09 kB
[@docodylus/expandable]: ✓ built in 2.61s
[@docodylus/expandable]: Generated an empty chunk: "index".
[@docodylus/expandable]: Generated an empty chunk: "index".
[@docodylus/expandable]: Process exited (exit code 0), completed in 3s 629ms
Done in 11s 990ms
```
</details>

### Unit Tests (aggregate, with coverage)
![Screenshot 2025-05-02 at 5 05 05 PM](https://github.com/user-attachments/assets/4521d873-c9a2-4a53-89b0-7bf9787c517d)

<details>
<summary>Text-output of full test run</summary>

```sh
iain@Iains-MacBook-Pro docodylus % yarn test:unit --coverage --run

 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus
      Coverage enabled with istanbul

 ✓ packages/common/loadable/internal/src/loaders/createLazyLoaders.test.ts (16 tests | 2 skipped) 21ms
 ✓ packages/common/i18n/internal/src/localeNegotiation/negotiateLocales.test.ts (18 tests) 6ms
 ✓ packages/common/i18n/internal/src/polyglot/LocaleAwarePolyglot.test.ts (8 tests) 5ms
 ✓ packages/common/i18n/internal/src/context/I18nProvider.test.tsx (7 tests) 27ms
 ✓ packages/components/layout/Expandable/src/test/Expandable.func.test.tsx (13 tests) 96ms
 ↓ test/integration/localeNegotiation.test.tsx (5 tests | 5 skipped)
stderr | packages/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all negotiated files have loaded
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"

stderr | packages/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Failed to load translations from https://mock-domain/localization/fr.txlns.ts: undefined

stderr | packages/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"

 ✓ packages/common/i18n/internal/src/hooks/useTranslations.test.tsx (11 tests) 112ms
 ↓ packages/components/layout/Expandable/src/test/Expandable.i18n-integration.test.tsx (9 tests | 9 skipped)
 ✓ packages/components/layout/Expandable/src/test/Expandable.a11y.test.tsx (13 tests) 351ms
 ✓ packages/common/error/internal/src/DocodylusErrorBase.test.ts (9 tests) 6ms
 ✓ packages/common/namespace/internal/src/isValidNamespace.test.ts (31 tests) 3ms
 ✓ packages/common/i18n/internal/src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests) 3ms
 ✓ packages/common/i18n/internal/src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 7ms
 ✓ packages/common/error/internal/src/DocodylusTypeError.test.ts (2 tests) 3ms
 ✓ packages/common/namespace/internal/src/createNamespacePrepender.test.ts (9 tests) 2ms
 ✓ packages/common/namespace/internal/src/error/newInvalidNamespaceError.test.ts (1 test) 6ms
 ✓ packages/common/i18n/internal/src/error/newInvalidLocaleError.test.ts (1 test) 5ms
 ✓ packages/common/i18n/internal/src/validation/validateLocale.test.ts (837 tests) 30ms

 Test Files  16 passed | 2 skipped (18)
      Tests  985 passed | 16 skipped (1001)
   Start at  17:04:49
   Duration  2.02s (transform 1.20s, setup 1.32s, collect 3.52s, tests 684ms, environment 5.69s, prepare 1.13s)

 % Coverage report from istanbul
-----------------------------------------------------|---------|----------|---------|---------|-------------------
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------------------------------|---------|----------|---------|---------|-------------------
All files                                            |     100 |      100 |     100 |     100 |                   
 common/consts/internal/src                          |     100 |      100 |     100 |     100 |                   
  consts.ts                                          |     100 |      100 |     100 |     100 |                   
 common/error/internal/src                           |     100 |      100 |     100 |     100 |                   
  DocodylusErrorBase.ts                              |     100 |      100 |     100 |     100 |                   
  DocodylusTypeError.ts                              |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src                            |     100 |      100 |     100 |     100 |                   
  consts.ts                                          |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/_generated                 |     100 |      100 |     100 |     100 |                   
  validLocales.ts                                    |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/context                    |     100 |      100 |     100 |     100 |                   
  I18nContext.tsx                                    |     100 |      100 |     100 |     100 |                   
  I18nProvider.tsx                                   |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/error                      |     100 |      100 |     100 |     100 |                   
  newInvalidLocaleError.ts                           |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/hooks                      |     100 |      100 |     100 |     100 |                   
  useTranslations.ts                                 |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/loaders                    |     100 |      100 |     100 |     100 |                   
  createLocalizationStringLoaders.ts                 |     100 |      100 |     100 |     100 |                   
  toLocalizationFileLoaderMap.ts                     |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/localeNegotiation          |     100 |      100 |     100 |     100 |                   
  negotiateLocales.ts                                |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/localization               |     100 |      100 |     100 |     100 |                   
  index.ts                                           |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/polyglot                   |     100 |      100 |     100 |     100 |                   
  LocaleAwarePolyglot.ts                             |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/validation                 |     100 |      100 |     100 |     100 |                   
  validateLocale.ts                                  |     100 |      100 |     100 |     100 |                   
 common/loadable/internal/src/loaders                |     100 |      100 |     100 |     100 |                   
  createLazyLoaders.ts                               |     100 |      100 |     100 |     100 |                   
 common/namespace/internal/src                       |     100 |      100 |     100 |     100 |                   
  createNamespacePrepender.ts                        |     100 |      100 |     100 |     100 |                   
  isValidNamespace.ts                                |     100 |      100 |     100 |     100 |                   
 common/namespace/internal/src/error                 |     100 |      100 |     100 |     100 |                   
  newInvalidNamespaceError.ts                        |     100 |      100 |     100 |     100 |                   
 components/layout/Expandable/src                    |     100 |      100 |     100 |     100 |                   
  Expandable.tsx                                     |     100 |      100 |     100 |     100 |                   
 components/layout/Expandable/src/localization       |     100 |      100 |     100 |     100 |                   
  index.ts                                           |     100 |      100 |     100 |     100 |                   
 components/layout/Expandable/src/localization/txlns |     100 |      100 |     100 |     100 |                   
  en.txlns.ts                                        |     100 |      100 |     100 |     100 |                   
  es.txlns.ts                                        |     100 |      100 |     100 |     100 |                   
-----------------------------------------------------|---------|----------|---------|---------|-------------------
```
</details>

### Integration Tests (aggregate, no coverage)
![Screenshot 2025-05-02 at 5 06 42 PM](https://github.com/user-attachments/assets/feaa5e33-b8be-4ca3-8d97-dea2eedfc778)

<details>
<summary>Text output of test run</summary>

```sh
iain@Iains-MacBook-Pro docodylus % yarn test:integration

 DEV  v3.1.2 /Users/iain/Projects/Developer/docodylus

 ↓ packages/common/i18n/internal/src/localeNegotiation/negotiateLocales.test.ts (18 tests | 18 skipped)
 ↓ packages/components/layout/Expandable/src/test/Expandable.func.test.tsx (13 tests | 13 skipped)
 ↓ packages/components/layout/Expandable/src/test/Expandable.a11y.test.tsx (13 tests | 13 skipped)
 ↓ packages/common/i18n/internal/src/hooks/useTranslations.test.tsx (11 tests | 11 skipped)
 ✓ test/integration/localeNegotiation.test.tsx (5 tests) 170ms
 ↓ packages/common/i18n/internal/src/polyglot/LocaleAwarePolyglot.test.ts (8 tests | 8 skipped)
 ✓ packages/common/loadable/internal/src/loaders/createLazyLoaders.test.ts (16 tests | 14 skipped) 7ms
 ↓ packages/common/i18n/internal/src/context/I18nProvider.test.tsx (7 tests | 7 skipped)
 ↓ packages/common/error/internal/src/DocodylusErrorBase.test.ts (9 tests | 9 skipped)
 ✓ packages/components/layout/Expandable/src/test/Expandable.i18n-integration.test.tsx (9 tests) 130ms
 ↓ packages/common/i18n/internal/src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests | 8 skipped)
 ✓ packages/common/i18n/internal/src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 5ms
 ↓ packages/common/namespace/internal/src/isValidNamespace.test.ts (31 tests | 31 skipped)
 ↓ packages/common/error/internal/src/DocodylusTypeError.test.ts (2 tests | 2 skipped)
 ↓ packages/common/namespace/internal/src/createNamespacePrepender.test.ts (9 tests | 9 skipped)
 ↓ packages/common/namespace/internal/src/error/newInvalidNamespaceError.test.ts (1 test | 1 skipped)
 ↓ packages/common/i18n/internal/src/error/newInvalidLocaleError.test.ts (1 test | 1 skipped)
 ✓ packages/common/i18n/internal/src/validation/validateLocale.test.ts (837 tests) 30ms

 Test Files  5 passed | 13 skipped (18)
      Tests  856 passed | 145 skipped (1001)
   Start at  17:06:31
   Duration  1.97s (transform 418ms, setup 688ms, collect 1.24s, tests 342ms, environment 3.48s, prepare 670ms)

 PASS  Waiting for file changes...
       press h to show help, press q to quit
```
</details>

### Additional checks
✅ Unit tests, run per-workspace with coverage
✅ successful build
✅ storybook starts and:
    * components load and display properly
    * docs load and display properly
    * i18n works as expected
