### PR TITLE
chore: update references in local files to obsolete 'prerelease' branch

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -4,7 +4,7 @@ on:
     push:
         branches:
             - main
-            - prerelease
+            - develop
 
 jobs:
     release:

--- a/infra/release/semantic-release.config.js
+++ b/infra/release/semantic-release.config.js
@@ -5,7 +5,7 @@ const getPackageJsonDirectories = () => {
   const filePaths = [
     '.', // root package.json path
     ...glob
-      .sync('src/**/package.json', { absolute: false })
+      .sync('packages/**/package.json', { absolute: false })
       .map((filePath) => filePath.replace('/package.json', '')),
   ];
 
@@ -24,7 +24,7 @@ const getNpmPluginConfigs = () => {
 export default {
   branches: [
     'main',
-    { name: 'prerelease', prerelease: 'prerelease' },
+    { name: 'develop', prerelease: 'prerelease' },
   ],
   plugins: [
     '@semantic-release/commit-analyzer',
@@ -36,7 +36,7 @@ export default {
       {
         assets: [
           'package.json',
-          'src/**/package.json',
+          'packages/**/package.json',
           'CHANGELOG.md',
         ],
         // eslint-disable-next-line no-template-curly-in-string


### PR DESCRIPTION
## Problem Statement
Decided to rename the branch which aggregates all changes prior to a release from `prerelease` to `develop` to bring it inline with standard practices. Most of this is in GitHub and git configurations, but a few repository files also reference the branch by name.

## Proposed solution
update file references to `prerelease` so they instead reference `develop`

## Validation
### Unit Tests (aggregate, with coverage)
![Screenshot 2025-05-02 at 5 30 33 PM](https://github.com/user-attachments/assets/5623a807-16eb-43b0-bd00-f26ee6d9baf1)

### Integration Tests (aggregate, no coverage)
![Screenshot 2025-05-02 at 5 32 09 PM](https://github.com/user-attachments/assets/18bf2419-d5d5-4f0b-bf49-e48bfa245da4)

### Bump-Version dry-run (config file has updated references)
![Screenshot 2025-05-02 at 5 33 32 PM](https://github.com/user-attachments/assets/4a2fdcc0-ac8c-4807-8260-0f503d6c46a2)

### Additional checks
✅ ran unit tests per-workspace
✅ successful build
✅ storybook runs and:
    * loads components
    * loads docs
    * i18n works