### PR TITLE
Chore/fix typechecking in unit tests

### DIFF
--- a/infra/test/tsconfig.type-test.json
+++ b/infra/test/tsconfig.type-test.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../build/tsconfig.base.json",
+    "include": [
+        "../../**/*.test-d.ts",
+        "../../packages/common/namespace/internal/src/isValidNamespace.ts",
+        "../../infra/test/utils/testGroups.ts"
+     ],
+     "exclude": [
+        "../../node_modules",
+     ],
+     "compilerOptions": {
+        "baseUrl": "../../",
+     }
+}

--- a/infra/test/tsconfig.type-test.json
+++ b/infra/test/tsconfig.type-test.json
@@ -2,7 +2,7 @@
     "extends": "../build/tsconfig.base.json",
     "include": [
         "../../**/*.test-d.ts",
-        "../../packages/common/namespace/internal/src/isValidNamespace.ts",
+        "../../**/*.testable-type.ts",
         "../../infra/test/utils/testGroups.ts"
      ],
      "exclude": [

--- a/infra/test/utils/testGroups.ts
+++ b/infra/test/utils/testGroups.ts
@@ -43,22 +43,22 @@ function checkGroups(groups: TestGroup | TestGroup[]): boolean {
  * Supplies the necessary boilerplate to ensure a block of tests runs
  * only when the UNIT test group (or none) is selected
  */
-export const describeUnitTest = describe.runIf(checkGroups(UNIT));
+export const describeUnitTest: ReturnType<typeof describe.runIf> = describe.runIf(checkGroups(UNIT));
 
 /**
  * Supplies the necessary boilerplate to ensure a block of tests runs
  * only when the INTEGRATION test group (or none) is selected
  */
-export const describeIntegrationTest = describe.runIf(checkGroups(INTEGRATION));
+export const describeIntegrationTest: ReturnType<typeof describe.runIf> = describe.runIf(checkGroups(INTEGRATION));
 
 /**
  * Supplies the necessary boilerplate to ensure a block of tests runs
  * only when the POLICY test group (or none) is selected
  */
-export const describePolicyTest = describe.runIf(checkGroups(POLICY));
+export const describePolicyTest: ReturnType<typeof describe.runIf> = describe.runIf(checkGroups(POLICY));
 
 /**
  * Supplies the necessary boilerplate to ensure a block of tests runs
  * only when the TYPE test group (or none) is selected
  */
-export const describeTypeTest = describe.runIf(checkGroups(TYPE));
+export const describeTypeTest: ReturnType<typeof describe.runIf> = describe.runIf(checkGroups(TYPE));

--- a/infra/test/vite.config.test-config.ts
+++ b/infra/test/vite.config.test-config.ts
@@ -1,4 +1,4 @@
-import { resolve } from "path";
+import path, { resolve } from "path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
@@ -13,7 +13,7 @@ export default defineConfig({
         },
         root: '.',
         typecheck: {
-            include: ['**/*.test-d.ts'],
+            tsconfig: path.resolve(__dirname, './tsconfig.type-test.json'),
         },
         include: [
             '**/*.{test,spec}.{js,ts,jsx,tsx}',

--- a/package.json
+++ b/package.json
@@ -91,10 +91,11 @@
     "build:since": "yarn workspaces foreach -pt --topological-dev --since=\"$SINCE\" run build",
     "build:changed": "SINCE=origin/main yarn build:since",
     "build:lastcommit": "SINCE=HEAD~1 yarn build:since",
-    "test:unit": "TEST_GROUP=UNIT vitest",
-    "test:unit-several": "yarn workspaces foreach -Ap run test:unit --run --passWithNoTests",
+    "test:unit": "TEST_GROUP=UNIT,TYPE vitest --typecheck",
+    "test:unit-each": "yarn workspaces foreach -Ap run test:unit --run --passWithNoTests",
     "test:types": "TEST_GROUP=TYPE vitest --typecheck",
     "test:integration": "TEST_GROUP=INTEGRATION vitest",
+    "test:integration-each": "TEST_GROUP=INTEGRATION yarn workspaces foreach -Ap run test:integration --run --passWithNoTests",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "bump-version": "semantic-release --extends ./infra/release/semantic-release.config.js"

--- a/packages/common/consts/internal/package.json
+++ b/packages/common/consts/internal/package.json
@@ -21,7 +21,7 @@
         "build": "../../../../node_modules/.bin/vite build",
         "clean": "rm -rf dist",
         "lint": "eslint . --ext .ts",
-        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run",
+        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run --typecheck",
         "test:integration": "TEST_GROUP=INTEGRATION ../../../../node_modules/.bin/vitest run"
     }
 }

--- a/packages/common/error/internal/package.json
+++ b/packages/common/error/internal/package.json
@@ -21,7 +21,7 @@
         "build": "../../../../node_modules/.bin/vite build",
         "clean": "rm -rf dist",
         "lint": "eslint . --ext .ts",
-        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run",
+        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run --typecheck",
         "test:integration": "TEST_GROUP=INTEGRATION ../../../../node_modules/.bin/vitest run"
     }
 }

--- a/packages/common/error/package.json
+++ b/packages/common/error/package.json
@@ -23,7 +23,7 @@
         "build": "../../../node_modules/.bin/vite build",
         "clean": "rm -rf dist",
         "lint": "eslint . --ext .ts",
-        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../node_modules/.bin/vitest run",
+        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../node_modules/.bin/vitest run --typecheck",
         "test:integration": "TEST_GROUP=INTEGRATION ../../../node_modules/.bin/vitest run"
     }
 }

--- a/packages/common/i18n/internal/package.json
+++ b/packages/common/i18n/internal/package.json
@@ -28,7 +28,7 @@
         "build": "yarn generate-locales; ../../../../node_modules/.bin/vite build",
         "clean": "rm -rf dist",
         "lint": "eslint . --ext .ts",
-        "test:unit": "TEST_GROUP=UNIT ../../../../node_modules/.bin/vitest run",
+        "test:unit": "TEST_GROUP=UNIT ../../../../node_modules/.bin/vitest run --typecheck",
         "test:integration": "TEST_GROUP=INTEGRATION ../../../../node_modules/.bin/vitest run"
     }
 }

--- a/packages/common/i18n/package.json
+++ b/packages/common/i18n/package.json
@@ -23,7 +23,7 @@
         "build": "../../../node_modules/.bin/vite build",
         "clean": "rm -rf dist",
         "lint": "eslint . --ext .ts",
-        "test:unit": "TEST_GROUP=UNIT ../../../node_modules/.bin/vitest run",
+        "test:unit": "TEST_GROUP=UNIT ../../../node_modules/.bin/vitest run --typecheck",
         "test:integration": "TEST_GROUP=INTEGRATION ../../../node_modules/.bin/vitest run"
     }
 }

--- a/packages/common/loadable/internal/package.json
+++ b/packages/common/loadable/internal/package.json
@@ -24,7 +24,7 @@
         "build": "../../../../node_modules/.bin/vite build",
         "clean": "rm -rf dist",
         "lint": "eslint . --ext .ts",
-        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run",
+        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run --typecheck",
         "test:integration": "TEST_GROUP=INTEGRATION ../../../../node_modules/.bin/vitest run"
     }
 }

--- a/packages/common/namespace/internal/index.ts
+++ b/packages/common/namespace/internal/index.ts
@@ -1,2 +1,3 @@
 export { createNamespacePrepender, type Namespaced } from './src/createNamespacePrepender';
-export { isValidNamespace, type ValidNamespace } from './src/isValidNamespace';
+export { isValidNamespace } from './src/isValidNamespace';
+export { type ValidNamespace } from './src/ValidNamespace.testable-type';

--- a/packages/common/namespace/internal/package.json
+++ b/packages/common/namespace/internal/package.json
@@ -21,7 +21,7 @@
         "build": "../../../../node_modules/.bin/vite build",
         "clean": "rm -rf dist",
         "lint": "eslint . --ext .ts",
-        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run",
+        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run --typecheck",
         "test:integration": "TEST_GROUP=INTEGRATION ../../../../node_modules/.bin/vitest run"
     },
     "dependencies": {

--- a/packages/common/namespace/internal/src/ValidNamespace.test-d.ts
+++ b/packages/common/namespace/internal/src/ValidNamespace.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import { describeTypeTest } from '@test-utils/testGroups'
-import { ValidNamespace } from './isValidNamespace';
+import type { ValidNamespace } from './ValidNamespace.testable-type';
 
 describeTypeTest('type ValidNamespace', () => {
   describe('valid namespace strings', () => {

--- a/packages/common/namespace/internal/src/ValidNamespace.testable-type.ts
+++ b/packages/common/namespace/internal/src/ValidNamespace.testable-type.ts
@@ -1,0 +1,24 @@
+import type { IsLowercase } from '@docodylus/validation-internal';
+
+/**
+ * Recursive type-level validator for dot-delimited, lowercase-only namespace strings.
+ */
+type IsValidNamespace<T extends string> =
+  T extends ''
+    ? false
+    : T extends `${infer Segment}.${infer Rest}`
+      ? Segment extends ''
+        ? false
+        : IsLowercase<Segment> extends true
+          ? IsValidNamespace<Rest>
+          : false
+      : IsLowercase<T> extends true
+        ? true
+        : false;
+
+/**
+ * Enforces a lowercase, dot-separated namespace.
+ * If the input string is invalid, it resolves to `never`.
+ */
+export type ValidNamespace<T extends string> =
+  IsValidNamespace<T> extends true ? T : never;

--- a/packages/common/namespace/internal/src/createNamespacePrepender.ts
+++ b/packages/common/namespace/internal/src/createNamespacePrepender.ts
@@ -1,6 +1,6 @@
 import { newInvalidNamespaceError } from './error/newInvalidNamespaceError';
 import { isValidNamespace } from './isValidNamespace';
-import { ValidNamespace } from './isValidNamespace'
+import { ValidNamespace } from './ValidNamespace.testable-type'
 
 export type Namespaced<NS extends string, T extends Record<string, unknown>> = {
     [K in keyof T as `${NS}.${string & K}`]: T[K]

--- a/packages/common/namespace/internal/src/isValidNamespace.test-d.ts
+++ b/packages/common/namespace/internal/src/isValidNamespace.test-d.ts
@@ -9,7 +9,7 @@ describeTypeTest('type ValidNamespace', () => {
     });
 
     it('should accept a string of all lowercase alpha', () => {
-      expectTypeOf<ValidNamespace<'abcde.fghij.klmnop'>>().not.toBeNever();
+      expectTypeOf<ValidNamespace<'abcde'>>().not.toBeNever();
     });
 
     it('should accept a string of all alpha lowercase alpha segments delimited by single dots', () => {
@@ -18,7 +18,7 @@ describeTypeTest('type ValidNamespace', () => {
 
     it('should accept a single-letter namespace', () => {
       // but don't do this.
-      expectTypeOf<ValidNamespace<'abcde.fghij.klmnop'>>().not.toBeNever();
+      expectTypeOf<ValidNamespace<'k'>>().not.toBeNever();
     });
   });
 

--- a/packages/common/namespace/internal/src/isValidNamespace.ts
+++ b/packages/common/namespace/internal/src/isValidNamespace.ts
@@ -1,28 +1,8 @@
-import type { IsLowercase } from '@docodylus/validation-internal';
+import { ValidNamespace } from "./ValidNamespace.testable-type";
 
 const namespaceRegex = /^([a-z]+\.)*[a-z]+$/;
 
-type IsValidNamespace<T extends string> =
-  T extends ''
-    // Reject empty string outright.
-    ? false
-    // segmented namespace
-    : T extends `${infer Segment}.${infer Rest}`
-        ? Segment extends ''
-            // Reject empty segment (leading or double dots)
-            ? false
-            : IsLowercase<Segment> extends true
-                // Recurse on the rest.
-                ? IsValidNamespace<Rest>
-                // reject if contains disallowed characters
-                : false
-            : IsLowercase<T> extends true
-                ? true
-                : false;
-
-export type ValidNamespace<T extends string> = IsValidNamespace<T> extends true ? T : never;
-
-export function isValidNamespace(maybeNamespace: unknown): boolean {
+export function isValidNamespace(maybeNamespace: unknown): maybeNamespace is ValidNamespace<string> {
   if (typeof maybeNamespace !== 'string') return false;
   return namespaceRegex.test(maybeNamespace);
 }

--- a/packages/common/validation/internal/package.json
+++ b/packages/common/validation/internal/package.json
@@ -21,6 +21,7 @@
         "build": "../../../../node_modules/.bin/vite build",
         "clean": "rm -rf dist",
         "lint": "eslint . --ext .ts",
-        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run"
+        "test:unit": "TEST_GROUP=UNIT,TYPE ../../../../node_modules/.bin/vitest run --typecheck",
+        "test:integration": "NODE_OPTIONS='--conditions development' TEST_GROUP=INTEGRATION ../../../../node_modules/.bin/vitest run"
     }
 }

--- a/packages/components/layout/Expandable/package.json
+++ b/packages/components/layout/Expandable/package.json
@@ -27,7 +27,7 @@
         "build": "../../../../node_modules/.bin/vite build",
         "clean": "rm -rf dist",
         "lint": "eslint . --ext .ts",
-        "test:unit": "TEST_GROUP=UNIT ../../../../node_modules/.bin/vitest run",
+        "test:unit": "TEST_GROUP=UNIT ../../../../node_modules/.bin/vitest run --typecheck",
         "test:integration": "NODE_OPTIONS='--conditions development' TEST_GROUP=INTEGRATION ../../../../node_modules/.bin/vitest run"
     }
 }


### PR DESCRIPTION
## Context
Recent work has involved significant changes in project structure and build technology. Files have been reorganized into a monorepo, and the build tool went from presumptively vite, to typescript's `tsc` compiler, and back to Vite again for building individual monorepo packages.

## Problem Statement
At some point in that process, typechecking tests stopped working, likely due to the changing scopes of **tsconfig.json** files. Typechecking has been recently disabled in order to allow work to proceed. The goal of the present change is to restore regular running of the type-checking tests.

## Proposed Solution
Investigate and implement the appropriate fix to restore type checks.

### Steps taken
* introduced type-check specific typescript config file: **infra/test/tsconfig.type-test.json**
* incorporated the same in **infra/test/vite.config.test.ts**
* Adopted new pattern of using an extension, `*.testable-type.ts` to identify files with types complex or critical enough to require testing. See notes.
* Moved `ValidNamespace` into a `*.testable-type.ts` file

## Incidental fixes
* Updated package.json scripts not just for unit tests, but for integration tests as well
    * ensured each package has a `test:integration` script
    * added a `test:integration-each` script to the root package.json to allow running integration tests in each module severally
* Changed the semantically and gramatticaly correct, but maybe a bit alienating `test:unit-several` to `test:unit-each`

## Notes
* The issue with failing type tests has been mostly due to what's included in the testable set by whatever **tsconfig.json** is active. By including the tested type, `ValidNamespace` in a `*.ts` file, everything else in that file became subject to typechecking, including everything that file imported.
    ```mermaid
    graph TD
       A[test-d.ts] --> B[isValidNamespace.ts]
      B --> C[Runtime deps]
      B --> D[Type deps]
    
      classDef type fill:#d0f0ff,stroke:#339,stroke-width:1px;
      classDef runtime fill:#ffe0e0,stroke:#933,stroke-width:1px;
      class B,D type;
      class C runtime;
    ```

    this had a cascading effect of bringing in wider and wider scopes of `*.ts` files to satisfy the imports, even though we don't want to type-check those files.
   
    Considered several approaches to solve this. The first approach was explicitly listing every file that had imports from a `*.test-d.ts` file. I hated the maintenance burden that was going to bring though. Other alternatives were considered, including using *.d.ts files and introducing a new extension prefix, at different levels of granularity. Ultimately I decided to add the new extension prefix to avoid confusing the semantics of `*.d.ts` files, and because we expect there to be very few of these types that are complex or critical enough to require explicit testing, I've adopted a per-file granularity.
    
    The new approach restores type-testing while limiting the maintenance burden on developers, and keeping it local to any new types introduced. Will have to document the pattern so devs know how to include their type-tests in unit test runs.

## Validation
### ✅ Unit Tests (aggregate, with coverage)
![Screenshot 2025-05-03 at 11 28 49 AM](https://github.com/user-attachments/assets/e987156c-ca12-447e-8c7b-e2f1c86d52b4)


_note: successful type-test file marked with `TS`_

<details>
<summary>full-text output of test run</summary>

```sh
iain@Iains-MacBook-Pro docodylus % yarn test:unit --coverage     
Testing types with tsc and vue-tsc is an experimental feature.
Breaking changes might not follow SemVer, please pin Vitest's version when using it.

 DEV  v3.1.2 /Users/iain/Projects/Developer/docodylus
      Coverage enabled with istanbul

 ✓ packages/common/i18n/internal/src/localeNegotiation/negotiateLocales.test.ts (18 tests) 6ms
 ✓ packages/components/layout/Expandable/src/test/Expandable.func.test.tsx (13 tests) 87ms
 ↓ test/integration/localeNegotiation.test.tsx (5 tests | 5 skipped)
stderr | packages/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all negotiated files have loaded
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"

stderr | packages/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Failed to load translations from https://mock-domain/localization/fr.txlns.ts: undefined

stderr | packages/common/i18n/internal/src/hooks/useTranslations.test.tsx > useTranslations hook > should indicate a loading state until all file loads have completed (with error)
Warning: Missing translation for key: "dev.iaindavis.test.unit.testProp3"

 ✓ packages/common/i18n/internal/src/hooks/useTranslations.test.tsx (11 tests) 102ms
 ✓  TS  packages/common/namespace/internal/src/ValidNamespace.test-d.ts (21 tests)
 ✓ packages/components/layout/Expandable/src/test/Expandable.a11y.test.tsx (13 tests) 301ms
 ✓ packages/common/i18n/internal/src/polyglot/LocaleAwarePolyglot.test.ts (8 tests) 5ms
 ✓ packages/common/loadable/internal/src/loaders/createLazyLoaders.test.ts (16 tests | 2 skipped) 11ms
 ↓ packages/components/layout/Expandable/src/test/Expandable.i18n-integration.test.tsx (9 tests | 9 skipped)
 ✓ packages/common/error/internal/src/DocodylusErrorBase.test.ts (9 tests) 6ms
 ✓ packages/common/i18n/internal/src/context/I18nProvider.test.tsx (7 tests) 27ms
 ✓ packages/common/i18n/internal/src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests) 3ms
 ✓ packages/common/i18n/internal/src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 5ms
 ✓ packages/common/namespace/internal/src/isValidNamespace.test.ts (31 tests) 4ms
 ✓ packages/common/error/internal/src/DocodylusTypeError.test.ts (2 tests) 2ms
 ✓ packages/common/namespace/internal/src/createNamespacePrepender.test.ts (9 tests) 2ms
 ✓ packages/common/namespace/internal/src/error/newInvalidNamespaceError.test.ts (1 test) 2ms
 ✓ packages/common/i18n/internal/src/error/newInvalidLocaleError.test.ts (1 test) 2ms
 ✓ packages/common/i18n/internal/src/validation/validateLocale.test.ts (837 tests) 31ms

 Test Files  17 passed | 2 skipped (19)
      Tests  1006 passed | 16 skipped (1022)
Type Errors  no errors
   Start at  11:17:58
   Duration  2.32s (transform 715ms, setup 769ms, collect 2.07s, tests 596ms, environment 3.55s, prepare 728ms, typecheck 990ms)

 % Coverage report from istanbul
-----------------------------------------------------|---------|----------|---------|---------|-------------------
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------------------------------|---------|----------|---------|---------|-------------------
All files                                            |     100 |      100 |     100 |     100 |                   
 common/consts/internal/src                          |     100 |      100 |     100 |     100 |                   
  consts.ts                                          |     100 |      100 |     100 |     100 |                   
 common/error/internal/src                           |     100 |      100 |     100 |     100 |                   
  DocodylusErrorBase.ts                              |     100 |      100 |     100 |     100 |                   
  DocodylusTypeError.ts                              |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src                            |     100 |      100 |     100 |     100 |                   
  consts.ts                                          |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/_generated                 |     100 |      100 |     100 |     100 |                   
  validLocales.ts                                    |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/context                    |     100 |      100 |     100 |     100 |                   
  I18nContext.tsx                                    |     100 |      100 |     100 |     100 |                   
  I18nProvider.tsx                                   |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/error                      |     100 |      100 |     100 |     100 |                   
  newInvalidLocaleError.ts                           |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/hooks                      |     100 |      100 |     100 |     100 |                   
  useTranslations.ts                                 |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/loaders                    |     100 |      100 |     100 |     100 |                   
  createLocalizationStringLoaders.ts                 |     100 |      100 |     100 |     100 |                   
  toLocalizationFileLoaderMap.ts                     |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/localeNegotiation          |     100 |      100 |     100 |     100 |                   
  negotiateLocales.ts                                |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/localization               |     100 |      100 |     100 |     100 |                   
  index.ts                                           |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/polyglot                   |     100 |      100 |     100 |     100 |                   
  LocaleAwarePolyglot.ts                             |     100 |      100 |     100 |     100 |                   
 common/i18n/internal/src/validation                 |     100 |      100 |     100 |     100 |                   
  validateLocale.ts                                  |     100 |      100 |     100 |     100 |                   
 common/loadable/internal/src/loaders                |     100 |      100 |     100 |     100 |                   
  createLazyLoaders.ts                               |     100 |      100 |     100 |     100 |                   
 common/namespace/internal/src                       |     100 |      100 |     100 |     100 |                   
  createNamespacePrepender.ts                        |     100 |      100 |     100 |     100 |                   
  isValidNamespace.ts                                |     100 |      100 |     100 |     100 |                   
 common/namespace/internal/src/error                 |     100 |      100 |     100 |     100 |                   
  newInvalidNamespaceError.ts                        |     100 |      100 |     100 |     100 |                   
 components/layout/Expandable/src                    |     100 |      100 |     100 |     100 |                   
  Expandable.tsx                                     |     100 |      100 |     100 |     100 |                   
 components/layout/Expandable/src/localization       |     100 |      100 |     100 |     100 |                   
  index.ts                                           |     100 |      100 |     100 |     100 |                   
 components/layout/Expandable/src/localization/txlns |     100 |      100 |     100 |     100 |                   
  en.txlns.ts                                        |     100 |      100 |     100 |     100 |                   
  es.txlns.ts                                        |     100 |      100 |     100 |     100 |                   
-----------------------------------------------------|---------|----------|---------|---------|-------------------
 PASS  Waiting for file changes...
       press h to show help, press q to quit

```
</details>

### ✅ Integration Tests (aggregate, no coverage)
![Screenshot 2025-05-03 at 11 29 34 AM](https://github.com/user-attachments/assets/ddb8a26b-d002-4759-9ad1-9e8f6a28d226)

<details>
<summary>full text output of test run</summary>

```sh
iain@Iains-MacBook-Pro docodylus % yarn test:integration --run  

 RUN  v3.1.2 /Users/iain/Projects/Developer/docodylus

 ✓ packages/common/loadable/internal/src/loaders/createLazyLoaders.test.ts (16 tests | 14 skipped) 17ms
 ↓ packages/common/i18n/internal/src/localeNegotiation/negotiateLocales.test.ts (18 tests | 18 skipped)
 ↓ packages/common/i18n/internal/src/polyglot/LocaleAwarePolyglot.test.ts (8 tests | 8 skipped)
 ↓ packages/common/i18n/internal/src/context/I18nProvider.test.tsx (7 tests | 7 skipped)
 ↓ packages/components/layout/Expandable/src/test/Expandable.func.test.tsx (13 tests | 13 skipped)
 ↓ packages/components/layout/Expandable/src/test/Expandable.a11y.test.tsx (13 tests | 13 skipped)
 ↓ packages/common/i18n/internal/src/hooks/useTranslations.test.tsx (11 tests | 11 skipped)
 ✓ packages/components/layout/Expandable/src/test/Expandable.i18n-integration.test.tsx (9 tests) 166ms
 ✓ test/integration/localeNegotiation.test.tsx (5 tests) 280ms
 ↓ packages/common/error/internal/src/DocodylusErrorBase.test.ts (9 tests | 9 skipped)
 ↓ packages/common/i18n/internal/src/loaders/toLocalizationFileLoaderMap.test.ts (8 tests | 8 skipped)
 ✓ packages/common/i18n/internal/src/loaders/createLocalizationStringLoaders.test.ts (3 tests) 7ms
 ↓ packages/common/namespace/internal/src/isValidNamespace.test.ts (31 tests | 31 skipped)
 ↓ packages/common/error/internal/src/DocodylusTypeError.test.ts (2 tests | 2 skipped)
 ↓ packages/common/namespace/internal/src/createNamespacePrepender.test.ts (9 tests | 9 skipped)
 ↓ packages/common/namespace/internal/src/error/newInvalidNamespaceError.test.ts (1 test | 1 skipped)
 ↓ packages/common/i18n/internal/src/error/newInvalidLocaleError.test.ts (1 test | 1 skipped)
 ✓ packages/common/i18n/internal/src/validation/validateLocale.test.ts (837 tests) 31ms

 Test Files  5 passed | 13 skipped (18)
      Tests  856 passed | 145 skipped (1001)
   Start at  11:22:36
   Duration  1.71s (transform 715ms, setup 1.03s, collect 2.14s, tests 502ms, environment 4.52s, prepare 1.12s)
```
</details>

### Additional checks
✅ unit tests, severally, with coverage (`yarn test:unit-each`)
✅ integration tests, severally, no coverage (`yarn test:integration-each`)
✅ successful build
✅ storybook starts and:
    * components load
    * documents load
    * i18n works as expected