### PR TITLE
chore: adding ADR folder and first example ADR

### DIFF
--- a/docs/adr/0001-define-adr-structure-and-format-for-project.md
+++ b/docs/adr/0001-define-adr-structure-and-format-for-project.md
@@ -1,0 +1,26 @@
+# 0001 - Define ADR Structure and Format for Project
+
+Date: 2025-06-10  
+Status: accepted  
+Tags: [infra]
+
+## Context
+
+As the Docodylus project evolves, we encounter architectural and infrastructure decisions that merit clear documentation. Without a consistent format or location for these records, contributors may struggle to understand the rationale behind past choices or the context in which they were made.
+
+## Decision
+
+We will record architectural decision records (ADRs) using the [MADR format](https://adr.github.io/madr/) in the `docs/adr/` directory of this repository. Each ADR will:
+
+- Be stored as an individual Markdown file
+- Use a numeric prefix for chronological ordering (e.g., `0001-title.md`)
+- Include frontmatter metadata for `status`, `date`, and optionally `tags`
+- Be manually added to the MkDocs navigation for now
+
+Future work may introduce tooling to automate navigation, rendering, or indexing.
+
+## Consequences
+
+- Establishes a durable and discoverable pattern for project-specific ADRs
+- Keeps decision history close to the source code and accessible via the documentation site
+- Enables future extension with MADR-compatible tools or viewers without format migration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,3 +26,4 @@ nav:
     - Build: ./infra/build.md
     - Release: ./infra/deploy.md
   - Architecture Decisions:
+    - "ADR 0001": ./adr/0001-define-adr-structure-and-format-for-project.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,4 +25,4 @@ nav:
   - Infra: 
     - Build: ./infra/build.md
     - Release: ./infra/deploy.md
-
+  - Architecture Decisions:


### PR DESCRIPTION
# [IDDEV-2][jira-iddev2]
---
## Context
Immediate future work involves making and document decisions.

## Problem Statement
No current infrastructure exists for documenting decisions, either within the  Docodylus project or in the wider IainDavis.dev org.

## Proposed Solution
Adopt and implement a decision-log policy for Docodylus and for IainDavis.dev

### In Scope for this PR
Decide on format, hosting, and presentation method for decision records within the Docodylus domain.

### Out of Scope for this PR
Decide on format, hosting, and presentation method for decision records within the broader IainDavis.dev domain, exclusive of Docodylus.


<!-- NAMED LINKS -->
[jira-iddev2]: https://iaindavis.atlassian.net/browse/IDDEV-2